### PR TITLE
feat(rtt): add channel RTT lanes and CI

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,5 @@
+self-hosted-runner:
+  labels:
+    - blacksmith-32vcpu-ubuntu-2404
+
+config-variables: null

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: UTC
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
             openclaw-rtt-ci-node-compile-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Lint workflows
-        uses: rhysd/actionlint@v1
+        uses: rhysd/actionlint@v1.7.12
 
       - name: Syntax
         run: node --check scripts/*.mjs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Syntax
+        run: node --check scripts/*.mjs
+
+      - name: Test
+        run: node --test scripts/*.test.mjs
+
+      - name: Validate data
+        run: node scripts/validate.mjs
+
+      - name: Verify README generation
+        shell: bash
+        run: |
+          set -euo pipefail
+          node scripts/update-readme.mjs
+          git diff --exit-code README.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,9 @@ jobs:
           restore-keys: |
             openclaw-rtt-ci-node-compile-${{ runner.os }}-${{ runner.arch }}-
 
+      - name: Lint workflows
+        uses: rhysd/actionlint@v1
+
       - name: Syntax
         run: node --check scripts/*.mjs
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ on:
 permissions:
   contents: read
 
+env:
+  NODE_COMPILE_CACHE: .cache/node-compile
+
 jobs:
   check:
     name: Check
@@ -23,6 +26,14 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 24
+
+      - name: Restore Node compile cache
+        uses: actions/cache@v5
+        with:
+          path: .cache/node-compile
+          key: openclaw-rtt-ci-node-compile-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('scripts/*.mjs') }}
+          restore-keys: |
+            openclaw-rtt-ci-node-compile-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Syntax
         run: node --check scripts/*.mjs

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,32 @@
+name: CodeQL
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  schedule:
+    - cron: "22 9 * * 1"
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze JavaScript
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: javascript-typescript
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v4

--- a/.github/workflows/main-channel-rtt.yml
+++ b/.github/workflows/main-channel-rtt.yml
@@ -1,12 +1,12 @@
-name: Main Discord RTT
+name: Main Channel RTT
 
 on:
   schedule:
-    - cron: "30 */6 * * *"
+    - cron: "45 */6 * * *"
   workflow_dispatch:
     inputs:
       samples:
-        description: Number of Discord canary RTT samples
+        description: Number of RTT samples
         required: false
         default: "20"
         type: string
@@ -15,7 +15,7 @@ permissions:
   contents: write
 
 concurrency:
-  group: main-discord-rtt
+  group: main-channel-rtt
   cancel-in-progress: false
 
 env:
@@ -25,10 +25,25 @@ env:
 
 jobs:
   measure:
-    name: Measure OpenClaw main Discord RTT
-    runs-on: ubuntu-24.04
+    name: Measure OpenClaw main ${{ matrix.label }} RTT
+    runs-on: blacksmith-32vcpu-ubuntu-2404
     timeout-minutes: 120
     environment: qa-live-shared
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix:
+        include:
+          - channel: slack
+            label: Slack
+            scenario: slack-canary
+            summary: slack-qa-summary.json
+            observed: slack-qa-observed-messages.json
+          - channel: whatsapp
+            label: WhatsApp
+            scenario: whatsapp-canary
+            summary: whatsapp-qa-summary.json
+            observed: whatsapp-qa-observed-messages.json
     steps:
       - name: Checkout RTT tracker
         uses: actions/checkout@v6
@@ -69,9 +84,9 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ${{ steps.pnpm-store.outputs.path }}
-          key: openclaw-main-discord-rtt-pnpm-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('openclaw/pnpm-lock.yaml') }}
+          key: openclaw-main-channel-rtt-pnpm-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('openclaw/pnpm-lock.yaml') }}
           restore-keys: |
-            openclaw-main-discord-rtt-pnpm-${{ runner.os }}-${{ runner.arch }}-
+            openclaw-main-channel-rtt-pnpm-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Install OpenClaw dependencies
         working-directory: openclaw
@@ -99,16 +114,16 @@ jobs:
           set -euo pipefail
           time pnpm build
 
-      - name: Run Discord RTT samples
-        id: discord_rtt
+      - name: Run ${{ matrix.label }} RTT samples
+        id: channel_rtt
         working-directory: openclaw
         env:
+          INPUT_SAMPLES: ${{ github.event_name == 'workflow_dispatch' && inputs.samples || '20' }}
           OPENCLAW_QA_CONVEX_SITE_URL: ${{ secrets.OPENCLAW_QA_CONVEX_SITE_URL }}
           OPENCLAW_QA_CONVEX_SECRET_CI: ${{ secrets.OPENCLAW_QA_CONVEX_SECRET_CI }}
           OPENCLAW_QA_CREDENTIAL_ACQUIRE_TIMEOUT_MS: "180000"
           OPENCLAW_QA_CREDENTIAL_HTTP_TIMEOUT_MS: "60000"
           OPENCLAW_QA_REDACT_PUBLIC_METADATA: "1"
-          INPUT_SAMPLES: ${{ github.event_name == 'workflow_dispatch' && inputs.samples || '20' }}
         shell: bash
         run: |
           set -euo pipefail
@@ -119,22 +134,22 @@ jobs:
             exit 1
           fi
 
-          output_root=".artifacts/qa-e2e/discord-rtt-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-          sample_paths="$RUNNER_TEMP/openclaw-discord-rtt-samples.tsv"
+          output_root=".artifacts/qa-e2e/${{ matrix.channel }}-rtt-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          sample_paths="$RUNNER_TEMP/openclaw-${{ matrix.channel }}-rtt-samples.tsv"
           : >"$sample_paths"
           echo "output_root=${output_root}" >>"$GITHUB_OUTPUT"
           echo "sample_paths=${sample_paths}" >>"$GITHUB_OUTPUT"
 
           for sample in $(seq 1 "$samples"); do
             output_dir="${output_root}/sample-${sample}"
-            summary_path="${output_dir}/discord-qa-summary.json"
-            observed_path="${output_dir}/discord-qa-observed-messages.json"
+            summary_path="${output_dir}/${{ matrix.summary }}"
+            observed_path="${output_dir}/${{ matrix.observed }}"
             status=1
             for attempt in 1 2 3; do
               rm -rf "$output_dir"
               mkdir -p "$output_dir"
               set +e
-              pnpm openclaw qa discord \
+              pnpm openclaw qa "${{ matrix.channel }}" \
                 --repo-root . \
                 --output-dir "${output_dir}" \
                 --provider-mode mock-openai \
@@ -143,42 +158,50 @@ jobs:
                 --fast \
                 --credential-source convex \
                 --credential-role ci \
-                --scenario discord-canary
+                --scenario "${{ matrix.scenario }}" \
+                --allow-failures
               status="$?"
               set -e
-              if [[ -f "$summary_path" && -f "$observed_path" ]]; then
+              if [[ -f "$summary_path" ]]; then
                 break
               fi
               if [[ "$attempt" -lt 3 ]]; then
                 sleep $((attempt * 15))
               fi
             done
-            if [[ ! -f "$summary_path" || ! -f "$observed_path" ]]; then
-              echo "No Discord QA artifacts produced for sample ${sample}." >&2
+            if [[ ! -f "$summary_path" ]]; then
+              echo "No ${{ matrix.label }} QA summary produced for sample ${sample}." >&2
               exit "$status"
             fi
-            printf '%s\t%s\n' "${PWD}/${summary_path}" "${PWD}/${observed_path}" >>"$sample_paths"
+            if [[ -f "$observed_path" ]]; then
+              printf '%s\t%s\n' "${PWD}/${summary_path}" "${PWD}/${observed_path}" >>"$sample_paths"
+            else
+              printf '%s\n' "${PWD}/${summary_path}" >>"$sample_paths"
+            fi
           done
 
-      - name: Import Discord RTT result
+      - name: Import ${{ matrix.label }} RTT result
         working-directory: openclaw-rtt
         shell: bash
         run: |
           set -euo pipefail
-          node scripts/import-discord-rtt.mjs "${{ steps.discord_rtt.outputs.sample_paths }}" \
+          git pull --rebase origin main
+          node scripts/import-live-transport-rtt.mjs "${{ steps.channel_rtt.outputs.sample_paths }}" \
+            --channel "${{ matrix.channel }}" \
             --spec openclaw@main \
             --version "${{ steps.openclaw_ref.outputs.version }}" \
-            --provider-mode mock-openai
-          node scripts/update-readme.mjs --latest-main-only
+            --provider-mode mock-openai \
+            --scenario "${{ matrix.scenario }}"
+          node scripts/update-readme.mjs
           node scripts/validate.mjs
-          node scripts/discord-rtt-summary.mjs
+          node scripts/channel-rtt-summary.mjs
 
-      - name: Upload Discord RTT artifacts
+      - name: Upload ${{ matrix.label }} RTT artifacts
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: main-discord-rtt-${{ github.run_id }}-${{ github.run_attempt }}
-          path: openclaw/.artifacts/qa-e2e/discord-rtt-${{ github.run_id }}-${{ github.run_attempt }}
+          name: main-${{ matrix.channel }}-rtt-${{ github.run_id }}-${{ github.run_attempt }}
+          path: openclaw/.artifacts/qa-e2e/${{ matrix.channel }}-rtt-${{ github.run_id }}-${{ github.run_attempt }}
           retention-days: 14
           if-no-files-found: warn
 
@@ -188,11 +211,11 @@ jobs:
         run: |
           set -euo pipefail
           if git diff --quiet --exit-code; then
-            echo "No Discord RTT changes to commit."
+            echo "No ${{ matrix.label }} RTT changes to commit."
             exit 0
           fi
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add README.md data/discord-rtt.jsonl discord-runs/
-          git commit -m "data: record main discord rtt"
+          git add README.md data/channel-rtt/${{ matrix.channel }}.jsonl channel-runs/${{ matrix.channel }}/
+          git commit -m "data: record main ${{ matrix.channel }} rtt"
           git push

--- a/.github/workflows/main-channel-rtt.yml
+++ b/.github/workflows/main-channel-rtt.yml
@@ -3,6 +3,15 @@ name: Main Channel RTT
 on:
   schedule:
     - cron: "45 */6 * * *"
+  pull_request:
+    paths:
+      - ".github/workflows/main-channel-rtt.yml"
+      - "scripts/channel-rtt-config.mjs"
+      - "scripts/channel-rtt-summary.mjs"
+      - "scripts/import-live-transport-rtt.mjs"
+      - "scripts/read-channel-rtt-rows.mjs"
+      - "scripts/update-readme.mjs"
+      - "scripts/validate.mjs"
   workflow_dispatch:
     inputs:
       samples:
@@ -121,7 +130,7 @@ jobs:
         id: channel_rtt
         working-directory: openclaw
         env:
-          INPUT_SAMPLES: ${{ github.event_name == 'workflow_dispatch' && inputs.samples || '20' }}
+          INPUT_SAMPLES: ${{ github.event_name == 'workflow_dispatch' && inputs.samples || '' }}
           OPENCLAW_QA_CONVEX_SITE_URL: ${{ secrets.OPENCLAW_QA_CONVEX_SITE_URL }}
           OPENCLAW_QA_CONVEX_SECRET_CI: ${{ secrets.OPENCLAW_QA_CONVEX_SECRET_CI }}
           OPENCLAW_QA_CREDENTIAL_ACQUIRE_TIMEOUT_MS: "180000"
@@ -131,7 +140,11 @@ jobs:
         run: |
           set -euo pipefail
 
-          samples="${INPUT_SAMPLES:-20}"
+          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+            samples="${INPUT_SAMPLES:-1}"
+          else
+            samples="${INPUT_SAMPLES:-20}"
+          fi
           if ! [[ "$samples" =~ ^[1-9][0-9]*$ ]]; then
             echo "samples must be a positive integer, got: $samples" >&2
             exit 1
@@ -213,7 +226,9 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          git pull --rebase origin main
+          if [[ "${GITHUB_EVENT_NAME}" != "pull_request" ]]; then
+            git pull --rebase origin main
+          fi
           node scripts/import-live-transport-rtt.mjs "${{ steps.channel_rtt.outputs.sample_paths }}" \
             --channel "${{ matrix.channel }}" \
             --spec openclaw@main \
@@ -234,6 +249,7 @@ jobs:
           if-no-files-found: warn
 
       - name: Commit result
+        if: github.event_name != 'pull_request'
         working-directory: openclaw-rtt
         shell: bash
         run: |

--- a/.github/workflows/main-channel-rtt.yml
+++ b/.github/workflows/main-channel-rtt.yml
@@ -202,7 +202,11 @@ jobs:
                 echo "attempts=${attempt}"
                 echo "exit_status=${status}"
               } >>"$metrics_path"
+              scenario_status=""
               if [[ -f "$summary_path" ]]; then
+                scenario_status="$(node -e 'const fs = require("node:fs"); const [summaryPath, scenarioId] = process.argv.slice(1); const summary = JSON.parse(fs.readFileSync(summaryPath, "utf8")); const scenario = Array.isArray(summary.scenarios) ? summary.scenarios.find((item) => item && item.id === scenarioId) : undefined; process.stdout.write(typeof scenario?.status === "string" ? scenario.status : "missing");' "$summary_path" "${{ matrix.scenario }}")"
+              fi
+              if [[ "$scenario_status" == "pass" ]]; then
                 break
               fi
               if [[ "$attempt" -lt "$max_attempts" ]]; then
@@ -210,7 +214,7 @@ jobs:
                 if [[ "$delay" -gt "$retry_max_seconds" ]]; then
                   delay="$retry_max_seconds"
                 fi
-                echo "No ${{ matrix.label }} QA summary for sample ${sample} attempt ${attempt}; retrying in ${delay}s." >&2
+                echo "${{ matrix.label }} QA sample ${sample} attempt ${attempt} did not pass (status=${scenario_status:-no-summary}); retrying in ${delay}s." >&2
                 sleep "$delay"
               fi
             done
@@ -238,7 +242,8 @@ jobs:
             --spec openclaw@main \
             --version "${{ steps.openclaw_ref.outputs.version }}" \
             --provider-mode mock-openai \
-            --scenario "${{ matrix.scenario }}"
+            --scenario "${{ matrix.scenario }}" \
+            --require-pass
           node scripts/update-readme.mjs
           node scripts/validate.mjs
           node scripts/channel-rtt-summary.mjs

--- a/.github/workflows/main-channel-rtt.yml
+++ b/.github/workflows/main-channel-rtt.yml
@@ -5,6 +5,9 @@ on:
     - cron: "45 */6 * * *"
   pull_request:
     paths:
+      - ".github/actionlint.yaml"
+      - ".github/workflows/ci.yml"
+      - ".github/workflows/codeql.yml"
       - ".github/workflows/main-channel-rtt.yml"
       - "scripts/channel-rtt-config.mjs"
       - "scripts/channel-rtt-summary.mjs"

--- a/.github/workflows/main-channel-rtt.yml
+++ b/.github/workflows/main-channel-rtt.yml
@@ -250,7 +250,7 @@ jobs:
 
       - name: Upload ${{ matrix.label }} RTT artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: main-${{ matrix.channel }}-rtt-${{ github.run_id }}-${{ github.run_attempt }}
           path: openclaw/.artifacts/qa-e2e/${{ matrix.channel }}-rtt-${{ github.run_id }}-${{ github.run_attempt }}

--- a/.github/workflows/main-channel-rtt.yml
+++ b/.github/workflows/main-channel-rtt.yml
@@ -31,6 +31,7 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   NODE_VERSION: "24.x"
   PNPM_VERSION: "10.33.0"
+  CHANNEL_RTT_PR_SAMPLES: "3"
   CHANNEL_RTT_MAX_ATTEMPTS: "3"
   CHANNEL_RTT_RETRY_BASE_SECONDS: "15"
   CHANNEL_RTT_RETRY_MAX_SECONDS: "60"
@@ -141,7 +142,7 @@ jobs:
           set -euo pipefail
 
           if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
-            samples="${INPUT_SAMPLES:-1}"
+            samples="${INPUT_SAMPLES:-$CHANNEL_RTT_PR_SAMPLES}"
           else
             samples="${INPUT_SAMPLES:-20}"
           fi

--- a/.github/workflows/main-channel-rtt.yml
+++ b/.github/workflows/main-channel-rtt.yml
@@ -144,12 +144,16 @@ jobs:
             output_dir="${output_root}/sample-${sample}"
             summary_path="${output_dir}/${{ matrix.summary }}"
             observed_path="${output_dir}/${{ matrix.observed }}"
+            metrics_path="${output_dir}/resource-metrics.env"
             status=1
             for attempt in 1 2 3; do
               rm -rf "$output_dir"
               mkdir -p "$output_dir"
               set +e
-              pnpm openclaw qa "${{ matrix.channel }}" \
+              /usr/bin/time \
+                -f 'max_rss_kb=%M\nelapsed_seconds=%e' \
+                -o "$metrics_path" \
+                pnpm openclaw qa "${{ matrix.channel }}" \
                 --repo-root . \
                 --output-dir "${output_dir}" \
                 --provider-mode mock-openai \
@@ -174,9 +178,9 @@ jobs:
               exit "$status"
             fi
             if [[ -f "$observed_path" ]]; then
-              printf '%s\t%s\n' "${PWD}/${summary_path}" "${PWD}/${observed_path}" >>"$sample_paths"
+              printf '%s\t%s\t%s\n' "${PWD}/${summary_path}" "${PWD}/${observed_path}" "${PWD}/${metrics_path}" >>"$sample_paths"
             else
-              printf '%s\n' "${PWD}/${summary_path}" >>"$sample_paths"
+              printf '%s\t\t%s\n' "${PWD}/${summary_path}" "${PWD}/${metrics_path}" >>"$sample_paths"
             fi
           done
 

--- a/.github/workflows/main-channel-rtt.yml
+++ b/.github/workflows/main-channel-rtt.yml
@@ -22,6 +22,9 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   NODE_VERSION: "24.x"
   PNPM_VERSION: "10.33.0"
+  CHANNEL_RTT_MAX_ATTEMPTS: "3"
+  CHANNEL_RTT_RETRY_BASE_SECONDS: "15"
+  CHANNEL_RTT_RETRY_MAX_SECONDS: "60"
 
 jobs:
   measure:
@@ -133,6 +136,16 @@ jobs:
             echo "samples must be a positive integer, got: $samples" >&2
             exit 1
           fi
+          max_attempts="${CHANNEL_RTT_MAX_ATTEMPTS:-3}"
+          retry_base_seconds="${CHANNEL_RTT_RETRY_BASE_SECONDS:-15}"
+          retry_max_seconds="${CHANNEL_RTT_RETRY_MAX_SECONDS:-60}"
+          for value_name in max_attempts retry_base_seconds retry_max_seconds; do
+            value="${!value_name}"
+            if ! [[ "$value" =~ ^[1-9][0-9]*$ ]]; then
+              echo "${value_name} must be a positive integer, got: ${value}" >&2
+              exit 1
+            fi
+          done
 
           output_root=".artifacts/qa-e2e/${{ matrix.channel }}-rtt-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           sample_paths="$RUNNER_TEMP/openclaw-${{ matrix.channel }}-rtt-samples.tsv"
@@ -146,9 +159,10 @@ jobs:
             observed_path="${output_dir}/${{ matrix.observed }}"
             metrics_path="${output_dir}/resource-metrics.env"
             status=1
-            for attempt in 1 2 3; do
+            for attempt in $(seq 1 "$max_attempts"); do
               rm -rf "$output_dir"
               mkdir -p "$output_dir"
+              echo "CHANNEL_RTT_PHASE:${{ matrix.channel }} sample=${sample}/${samples} attempt=${attempt}/${max_attempts}"
               set +e
               /usr/bin/time \
                 -f 'max_rss_kb=%M\nelapsed_seconds=%e' \
@@ -166,11 +180,21 @@ jobs:
                 --allow-failures
               status="$?"
               set -e
+              {
+                echo "sample=${sample}"
+                echo "attempts=${attempt}"
+                echo "exit_status=${status}"
+              } >>"$metrics_path"
               if [[ -f "$summary_path" ]]; then
                 break
               fi
-              if [[ "$attempt" -lt 3 ]]; then
-                sleep $((attempt * 15))
+              if [[ "$attempt" -lt "$max_attempts" ]]; then
+                delay=$((retry_base_seconds * (2 ** (attempt - 1))))
+                if [[ "$delay" -gt "$retry_max_seconds" ]]; then
+                  delay="$retry_max_seconds"
+                fi
+                echo "No ${{ matrix.label }} QA summary for sample ${sample} attempt ${attempt}; retrying in ${delay}s." >&2
+                sleep "$delay"
               fi
             done
             if [[ ! -f "$summary_path" ]]; then

--- a/.github/workflows/main-discord-rtt.yml
+++ b/.github/workflows/main-discord-rtt.yml
@@ -175,7 +175,7 @@ jobs:
 
       - name: Upload Discord RTT artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: main-discord-rtt-${{ github.run_id }}-${{ github.run_attempt }}
           path: openclaw/.artifacts/qa-e2e/discord-rtt-${{ github.run_id }}-${{ github.run_attempt }}

--- a/.github/workflows/main-rtt.yml
+++ b/.github/workflows/main-rtt.yml
@@ -36,6 +36,7 @@ jobs:
           ref: main
           path: openclaw
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Set up Blacksmith Docker Builder
         uses: useblacksmith/setup-docker-builder@722e97d12b1d06a961800dd6c05d79d951ad3c80 # v1

--- a/.github/workflows/stable-release-rtt.yml
+++ b/.github/workflows/stable-release-rtt.yml
@@ -50,6 +50,7 @@ jobs:
           ref: main
           path: openclaw
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Set up Blacksmith Docker Builder
         if: steps.release.outputs.should_run == 'true'

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ pnpm rtt openclaw@2026.4.30 --provider live-frontier
 - `runs/<run-id>/result.json`: copied per-run result record for audit/debug.
 - `data/discord-rtt.jsonl`: append-only Discord RTT graph source.
 - `discord-runs/<run-id>/result.json`: copied per-run Discord RTT record.
+- `data/channel-rtt/<channel>.jsonl`: append-only graph source for new live-transport channel RTT runs.
+- `channel-runs/<channel>/<run-id>/result.json`: copied per-run channel result record.
 
 Raw Telegram QA artifacts stay in the OpenClaw repo artifact directory unless explicitly copied in later.
 
@@ -91,3 +93,13 @@ Measured with the OpenClaw Discord QA harness using `mock-openai`, scenario `dis
 No release RTT runs have been imported yet.
 
 <!-- discord-release-sweep:end -->
+
+## Channel Expansion
+
+Generic live-transport RTT imports for channels backed by `pnpm openclaw qa <channel>`. New channels should land one at a time with their workflow, credential contract, scenario id, and importer proof.
+
+<!-- channel-rtt:start -->
+
+No channel RTT runs have been imported yet.
+
+<!-- channel-rtt:end -->

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ No release RTT runs have been imported yet.
 ## Channel Expansion
 
 Generic live-transport RTT imports for channels backed by `pnpm openclaw qa <channel>`. New channels should land one at a time with their workflow, credential contract, scenario id, and importer proof.
+Design notes: [Channel expansion](docs/channel-expansion.md).
 
 <!-- channel-rtt:start -->
 

--- a/docs/channel-expansion.md
+++ b/docs/channel-expansion.md
@@ -20,6 +20,7 @@ Required pieces:
 - Add or extend a workflow that runs `pnpm openclaw qa <channel>` with Convex-managed CI credentials and `OPENCLAW_QA_REDACT_PUBLIC_METADATA=1`.
 - Import with `scripts/import-live-transport-rtt.mjs`, passing the summary TSV, channel id, `openclaw@main` or release spec, version/ref, provider mode, and scenario id.
 - Capture per-sample resource metrics with `/usr/bin/time` and include the metrics path in the importer TSV so RSS appears beside RTT in the dashboard.
+- Record the attempt count in the resource metrics file. The importer stores per-sample attempts and aggregate retry count so the dashboard can show when a green sample needed transient recovery.
 - Commit only `README.md`, `data/channel-rtt/<channel>.jsonl`, and `channel-runs/<channel>/`.
 - Add importer proof with `node --test` when the new channel has a new artifact shape.
 
@@ -27,7 +28,7 @@ Required pieces:
 
 `main-channel-rtt.yml` starts with Slack and WhatsApp because both are built-in OpenClaw live transports and their summaries already carry scenario-level RTT fields. The workflow runs channels serially to avoid competing README/data commits.
 
-Each sample is wrapped with `/usr/bin/time` and imports max RSS in kilobytes alongside the scenario RTT. The README renders RTT p50/p95 and RSS p50/max for the latest run per channel/spec.
+Each sample is wrapped with `/usr/bin/time` and imports max RSS in kilobytes alongside the scenario RTT. The workflow uses bounded exponential retry for transient missing-summary failures and writes the final attempt count into the imported row. The README renders retries, RTT p50/p95, and RSS p50/max for the latest run per channel/spec.
 
 Discord is intentionally not migrated in the same step. Its summary currently omits RTT fields, so the generic importer supports observed-message timestamp fallback and has test coverage for that path, but the existing Discord workflow remains stable while the new channel lane proves itself.
 

--- a/docs/channel-expansion.md
+++ b/docs/channel-expansion.md
@@ -19,12 +19,15 @@ Required pieces:
 - Add the channel id, display label, CLI command, and default canary scenario in `scripts/channel-rtt-config.mjs`.
 - Add or extend a workflow that runs `pnpm openclaw qa <channel>` with Convex-managed CI credentials and `OPENCLAW_QA_REDACT_PUBLIC_METADATA=1`.
 - Import with `scripts/import-live-transport-rtt.mjs`, passing the summary TSV, channel id, `openclaw@main` or release spec, version/ref, provider mode, and scenario id.
+- Capture per-sample resource metrics with `/usr/bin/time` and include the metrics path in the importer TSV so RSS appears beside RTT in the dashboard.
 - Commit only `README.md`, `data/channel-rtt/<channel>.jsonl`, and `channel-runs/<channel>/`.
 - Add importer proof with `node --test` when the new channel has a new artifact shape.
 
 ## First Wave
 
 `main-channel-rtt.yml` starts with Slack and WhatsApp because both are built-in OpenClaw live transports and their summaries already carry scenario-level RTT fields. The workflow runs channels serially to avoid competing README/data commits.
+
+Each sample is wrapped with `/usr/bin/time` and imports max RSS in kilobytes alongside the scenario RTT. The README renders RTT p50/p95 and RSS p50/max for the latest run per channel/spec.
 
 Discord is intentionally not migrated in the same step. Its summary currently omits RTT fields, so the generic importer supports observed-message timestamp fallback and has test coverage for that path, but the existing Discord workflow remains stable while the new channel lane proves itself.
 

--- a/docs/channel-expansion.md
+++ b/docs/channel-expansion.md
@@ -1,0 +1,50 @@
+# Channel Expansion
+
+`openclaw-rtt` should stay a data repository, not become a second QA harness. The harness lives in `openclaw/openclaw`; this repo imports normalized timing rows, regenerates the README dashboard, and records enough per-run JSON to audit a bad point on the graph.
+
+## Current State
+
+- Telegram main/release RTT still uses the older `pnpm rtt` result shape and writes `data/rtt.jsonl`.
+- Discord main RTT uses the live QA lane but has its own importer and writes `data/discord-rtt.jsonl`.
+- Release Discord, Slack, WhatsApp, Matrix, iMessage, Microsoft Teams, and future channels had no reusable data lane here.
+- CI only measured live scheduled data. It did not protect PRs that change importers, README generation, or workflows.
+- Scheduled workflows needed `contents: write` to commit results, but secondary OpenClaw checkouts did not need persisted credentials.
+
+## New Channel Contract
+
+New live transport channels should use the channel RTT lane when the OpenClaw CLI exposes `pnpm openclaw qa <channel>` and the lane emits a QA summary artifact.
+
+Required pieces:
+
+- Add the channel id, display label, CLI command, and default canary scenario in `scripts/channel-rtt-config.mjs`.
+- Add or extend a workflow that runs `pnpm openclaw qa <channel>` with Convex-managed CI credentials and `OPENCLAW_QA_REDACT_PUBLIC_METADATA=1`.
+- Import with `scripts/import-live-transport-rtt.mjs`, passing the summary TSV, channel id, `openclaw@main` or release spec, version/ref, provider mode, and scenario id.
+- Commit only `README.md`, `data/channel-rtt/<channel>.jsonl`, and `channel-runs/<channel>/`.
+- Add importer proof with `node --test` when the new channel has a new artifact shape.
+
+## First Wave
+
+`main-channel-rtt.yml` starts with Slack and WhatsApp because both are built-in OpenClaw live transports and their summaries already carry scenario-level RTT fields. The workflow runs channels serially to avoid competing README/data commits.
+
+Discord is intentionally not migrated in the same step. Its summary currently omits RTT fields, so the generic importer supports observed-message timestamp fallback and has test coverage for that path, but the existing Discord workflow remains stable while the new channel lane proves itself.
+
+Telegram is listed in the channel config for the future live-transport path, but the current production graph remains on the older `pnpm rtt` package-result path because that is what release sweeps already use.
+
+## CI And Security
+
+- `CI` checks script syntax, importer tests, data validation, and README regeneration on PRs.
+- `CodeQL` enables JavaScript analysis for importer/workflow-support code.
+- Dependabot tracks GitHub Action updates.
+- Secondary `openclaw/openclaw` checkouts use `persist-credentials: false`.
+- Live QA workflows redact public metadata before writing artifacts.
+
+## Next Channels
+
+Recommended order:
+
+1. Discord release RTT via the generic importer once the main lane has produced channel data.
+2. Telegram live-transport main RTT if we want one dashboard shape for all channel canaries.
+3. Matrix once its QA runner is available as a stable `pnpm openclaw qa <channel>` contribution in the release artifact.
+4. iMessage and Microsoft Teams after they expose equivalent live transport summaries and CI-safe credentials.
+
+Do not add a channel by copying an entire bespoke importer. That path looks fast once and then becomes boring maintenance debt.

--- a/package.json
+++ b/package.json
@@ -4,10 +4,14 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "channel-rtt-summary": "node scripts/channel-rtt-summary.mjs",
+    "check": "node --check scripts/*.mjs && node scripts/validate.mjs && node scripts/update-readme.mjs && git diff --exit-code README.md",
     "discord-rtt-summary": "node scripts/discord-rtt-summary.mjs",
+    "import-live-transport-rtt": "node scripts/import-live-transport-rtt.mjs",
     "import-result": "node scripts/import-result.mjs",
     "import-discord-rtt": "node scripts/import-discord-rtt.mjs",
     "summary": "node scripts/summary.mjs",
+    "test": "node --test scripts/*.test.mjs",
     "update-readme": "node scripts/update-readme.mjs",
     "validate": "node scripts/validate.mjs"
   },

--- a/scripts/channel-rtt-config.mjs
+++ b/scripts/channel-rtt-config.mjs
@@ -1,0 +1,46 @@
+export const CHANNEL_RTT_DATA_DIR = "data/channel-rtt";
+export const CHANNEL_RTT_RUNS_DIR = "channel-runs";
+
+export const CHANNEL_RTT_CHANNELS = {
+  discord: {
+    command: "discord",
+    defaultScenario: "discord-canary",
+    label: "Discord",
+  },
+  slack: {
+    command: "slack",
+    defaultScenario: "slack-canary",
+    label: "Slack",
+  },
+  telegram: {
+    command: "telegram",
+    defaultScenario: "telegram-mentioned-message-reply",
+    label: "Telegram",
+  },
+  whatsapp: {
+    command: "whatsapp",
+    defaultScenario: "whatsapp-canary",
+    label: "WhatsApp",
+  },
+};
+
+export function listChannelRttChannels() {
+  return Object.entries(CHANNEL_RTT_CHANNELS).map(([id, channel]) => ({ id, ...channel }));
+}
+
+export function resolveChannelRttChannel(id) {
+  const channel = CHANNEL_RTT_CHANNELS[id];
+  if (!channel) {
+    const known = Object.keys(CHANNEL_RTT_CHANNELS).sort().join(", ");
+    throw new Error(`Unknown channel RTT channel: ${id}. Known channels: ${known}`);
+  }
+  return { id, ...channel };
+}
+
+export function channelRttDataPath(channelId) {
+  return `${CHANNEL_RTT_DATA_DIR}/${channelId}.jsonl`;
+}
+
+export function channelRttRunsDir(channelId) {
+  return `${CHANNEL_RTT_RUNS_DIR}/${channelId}`;
+}

--- a/scripts/channel-rtt-summary.mjs
+++ b/scripts/channel-rtt-summary.mjs
@@ -4,6 +4,10 @@ function formatMs(value) {
   return typeof value === "number" ? `${Math.round(value)}ms` : "-";
 }
 
+function formatRss(value) {
+  return typeof value === "number" ? `${Math.round(value / 1024)}MB` : "-";
+}
+
 const rows = await readChannelRttRows();
 if (rows.length === 0) {
   process.stdout.write("No channel RTT rows yet.\n");
@@ -26,8 +30,10 @@ for (const row of rows.slice(-10)) {
       row.package.version,
       row.run.status,
       `samples=${row.rtt.warmSamples?.length ?? 0}`,
-      `p50=${formatMs(row.rtt.p50Ms)}`,
-      `p95=${formatMs(row.rtt.p95Ms)}`,
+      `rtt_p50=${formatMs(row.rtt.p50Ms)}`,
+      `rtt_p95=${formatMs(row.rtt.p95Ms)}`,
+      `rss_p50=${formatRss(row.resources?.maxRssKb?.p50)}`,
+      `rss_p95=${formatRss(row.resources?.maxRssKb?.p95)}`,
     ].join("  "),
   );
   process.stdout.write("\n");

--- a/scripts/channel-rtt-summary.mjs
+++ b/scripts/channel-rtt-summary.mjs
@@ -1,0 +1,34 @@
+import { readChannelRttRows } from "./read-channel-rtt-rows.mjs";
+
+function formatMs(value) {
+  return typeof value === "number" ? `${Math.round(value)}ms` : "-";
+}
+
+const rows = await readChannelRttRows();
+if (rows.length === 0) {
+  process.stdout.write("No channel RTT rows yet.\n");
+  process.exit(0);
+}
+
+const latest = rows.at(-1);
+process.stdout.write(`Channel RTT runs: ${rows.length}\n`);
+process.stdout.write(
+  `Latest: ${latest.channel.id} ${latest.package.spec} ${latest.package.version} ${latest.run.status} samples=${latest.rtt.warmSamples?.length ?? 0} p50=${formatMs(latest.rtt.p50Ms)} p95=${formatMs(latest.rtt.p95Ms)}\n`,
+);
+
+for (const row of rows.slice(-10)) {
+  process.stdout.write(
+    [
+      row.run.startedAt,
+      row.channel.id,
+      row.channel.scenario,
+      row.package.spec,
+      row.package.version,
+      row.run.status,
+      `samples=${row.rtt.warmSamples?.length ?? 0}`,
+      `p50=${formatMs(row.rtt.p50Ms)}`,
+      `p95=${formatMs(row.rtt.p95Ms)}`,
+    ].join("  "),
+  );
+  process.stdout.write("\n");
+}

--- a/scripts/channel-rtt-summary.mjs
+++ b/scripts/channel-rtt-summary.mjs
@@ -30,6 +30,7 @@ for (const row of rows.slice(-10)) {
       row.package.version,
       row.run.status,
       `samples=${row.rtt.warmSamples?.length ?? 0}`,
+      `retries=${row.polling?.retryCount ?? 0}`,
       `rtt_p50=${formatMs(row.rtt.p50Ms)}`,
       `rtt_p95=${formatMs(row.rtt.p95Ms)}`,
       `rss_p50=${formatRss(row.resources?.maxRssKb?.p50)}`,

--- a/scripts/import-live-transport-rtt.mjs
+++ b/scripts/import-live-transport-rtt.mjs
@@ -14,6 +14,7 @@ function usage() {
     "  --version <version-or-ref>",
     "  [--provider-mode <mock-openai|live-frontier>]",
     "  [--scenario <scenario-id>]",
+    "  [--require-pass]",
   ].join("\n");
 }
 
@@ -43,6 +44,10 @@ function parseArgs(argv) {
     }
     if (arg === "--scenario") {
       args.scenario = argv[(index += 1)];
+      continue;
+    }
+    if (arg === "--require-pass") {
+      args.requirePass = true;
       continue;
     }
     throw new Error(`Unknown argument: ${arg}\n${usage()}`);
@@ -362,6 +367,9 @@ async function main() {
   await fs.mkdir(path.dirname(dataPath), { recursive: true });
   await fs.appendFile(dataPath, `${JSON.stringify(result)}\n`);
   process.stdout.write(`imported ${runId}\n`);
+  if (args.requirePass && result.run.status !== "pass") {
+    throw new Error(`Channel RTT run failed: ${runId}`);
+  }
 }
 
 main().catch((error) => {

--- a/scripts/import-live-transport-rtt.mjs
+++ b/scripts/import-live-transport-rtt.mjs
@@ -111,6 +111,17 @@ function stats(samples) {
   };
 }
 
+function numericStats(samples) {
+  const sorted = [...samples].sort((left, right) => left - right);
+  const total = sorted.reduce((sum, value) => sum + value, 0);
+  return {
+    avg: sorted.length ? total / sorted.length : undefined,
+    p50: quantile(sorted, 0.5),
+    p95: quantile(sorted, 0.95),
+    max: sorted.at(-1),
+  };
+}
+
 async function readJson(pathname) {
   return JSON.parse(await fs.readFile(pathname, "utf8"));
 }
@@ -121,11 +132,11 @@ async function readSampleEntries(samplesPath) {
     .split("\n")
     .filter(Boolean)
     .map((line, index) => {
-      const [summaryPath, observedMessagesPath] = line.split("\t");
+      const [summaryPath, observedMessagesPath, resourceMetricsPath] = line.split("\t");
       if (!summaryPath) {
         throw new Error(`Invalid sample-paths line ${index + 1}: expected summary path.`);
       }
-      return { summaryPath, observedMessagesPath };
+      return { summaryPath, observedMessagesPath, resourceMetricsPath };
     });
 }
 
@@ -170,6 +181,25 @@ function extractObservedRtt(observedMessages, scenarioId) {
   return Number.isFinite(rttMs) ? rttMs : undefined;
 }
 
+async function readResourceMetrics(pathname) {
+  if (!pathname) {
+    return {};
+  }
+  const text = await fs.readFile(path.resolve(pathname), "utf8");
+  const metrics = {};
+  for (const line of text.split("\n")) {
+    const [key, value] = line.split("=");
+    if (!key || value === undefined) {
+      continue;
+    }
+    const numeric = Number(value);
+    if (Number.isFinite(numeric)) {
+      metrics[key] = numeric;
+    }
+  }
+  return metrics;
+}
+
 function selectScenario(summary, scenarioId) {
   const scenario = summary.scenarios.find((item) => item?.id === scenarioId);
   if (!scenario) {
@@ -186,9 +216,18 @@ async function readSample(entry, index, scenarioId) {
   if (rttMs === undefined && entry.observedMessagesPath) {
     rttMs = extractObservedRtt(await readJson(path.resolve(entry.observedMessagesPath)), scenarioId);
   }
+  const resourceMetrics = await readResourceMetrics(entry.resourceMetricsPath);
   return {
     index,
     summary,
+    resources: {
+      ...(resourceMetrics.max_rss_kb === undefined
+        ? {}
+        : { maxRssKb: resourceMetrics.max_rss_kb }),
+      ...(resourceMetrics.elapsed_seconds === undefined
+        ? {}
+        : { elapsedSeconds: resourceMetrics.elapsed_seconds }),
+    },
     scenario: {
       details: scenario.details,
       id: scenario.id,
@@ -241,6 +280,12 @@ async function main() {
   const warmSamples = samples.flatMap((sample) =>
     sample.scenario.status === "pass" ? [sample.scenario.rttMs] : [],
   );
+  const maxRssKbSamples = samples.flatMap((sample) =>
+    typeof sample.resources.maxRssKb === "number" ? [sample.resources.maxRssKb] : [],
+  );
+  const elapsedSecondsSamples = samples.flatMap((sample) =>
+    typeof sample.resources.elapsedSeconds === "number" ? [sample.resources.elapsedSeconds] : [],
+  );
   const failedSamples = samples.length - warmSamples.length;
   const runDir = path.join(channelRttRunsDir(channel.id), runId);
   const resultPath = path.join(runDir, "result.json");
@@ -271,10 +316,20 @@ async function main() {
       failedSamples,
       ...stats(warmSamples),
     },
+    resources: {
+      maxRssKbSamples,
+      elapsedSecondsSamples,
+      maxRssKb: numericStats(maxRssKbSamples),
+      elapsedSeconds: numericStats(elapsedSecondsSamples),
+    },
     samples: samples.map((sample) => ({
       index: sample.index,
       status: sample.scenario.status,
       ...(sample.scenario.rttMs === undefined ? {} : { rttMs: sample.scenario.rttMs }),
+      ...(sample.resources.maxRssKb === undefined ? {} : { maxRssKb: sample.resources.maxRssKb }),
+      ...(sample.resources.elapsedSeconds === undefined
+        ? {}
+        : { elapsedSeconds: sample.resources.elapsedSeconds }),
       ...(sample.scenario.details ? { details: sample.scenario.details } : {}),
     })),
     artifacts: {

--- a/scripts/import-live-transport-rtt.mjs
+++ b/scripts/import-live-transport-rtt.mjs
@@ -200,6 +200,16 @@ async function readResourceMetrics(pathname) {
   return metrics;
 }
 
+function readAttemptCount(value) {
+  if (value === undefined) {
+    return 1;
+  }
+  if (!Number.isInteger(value) || value < 1) {
+    throw new Error("resource metrics attempts must be a positive integer.");
+  }
+  return value;
+}
+
 function selectScenario(summary, scenarioId) {
   const scenario = summary.scenarios.find((item) => item?.id === scenarioId);
   if (!scenario) {
@@ -217,9 +227,11 @@ async function readSample(entry, index, scenarioId) {
     rttMs = extractObservedRtt(await readJson(path.resolve(entry.observedMessagesPath)), scenarioId);
   }
   const resourceMetrics = await readResourceMetrics(entry.resourceMetricsPath);
+  const attempts = readAttemptCount(resourceMetrics.attempts);
   return {
     index,
     summary,
+    attempts,
     resources: {
       ...(resourceMetrics.max_rss_kb === undefined
         ? {}
@@ -286,6 +298,8 @@ async function main() {
   const elapsedSecondsSamples = samples.flatMap((sample) =>
     typeof sample.resources.elapsedSeconds === "number" ? [sample.resources.elapsedSeconds] : [],
   );
+  const attemptSamples = samples.map((sample) => sample.attempts);
+  const retryCount = attemptSamples.reduce((total, attempts) => total + Math.max(0, attempts - 1), 0);
   const failedSamples = samples.length - warmSamples.length;
   const runDir = path.join(channelRttRunsDir(channel.id), runId);
   const resultPath = path.join(runDir, "result.json");
@@ -306,6 +320,11 @@ async function main() {
       durationMs: finishedAtMs - startedAtMs,
       status: failedSamples === 0 ? "pass" : "fail",
     },
+    polling: {
+      attemptSamples,
+      retryCount,
+      maxAttempts: Math.max(...attemptSamples),
+    },
     mode: {
       providerMode: args.providerMode,
       credentialSource: samples[0].summary.credentials?.source,
@@ -325,6 +344,7 @@ async function main() {
     samples: samples.map((sample) => ({
       index: sample.index,
       status: sample.scenario.status,
+      attempts: sample.attempts,
       ...(sample.scenario.rttMs === undefined ? {} : { rttMs: sample.scenario.rttMs }),
       ...(sample.resources.maxRssKb === undefined ? {} : { maxRssKb: sample.resources.maxRssKb }),
       ...(sample.resources.elapsedSeconds === undefined

--- a/scripts/import-live-transport-rtt.mjs
+++ b/scripts/import-live-transport-rtt.mjs
@@ -1,0 +1,295 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import {
+  channelRttDataPath,
+  channelRttRunsDir,
+  resolveChannelRttChannel,
+} from "./channel-rtt-config.mjs";
+
+function usage() {
+  return [
+    "Usage: node scripts/import-live-transport-rtt.mjs <sample-paths.tsv>",
+    "  --channel <discord|slack|telegram|whatsapp>",
+    "  --spec <openclaw@spec>",
+    "  --version <version-or-ref>",
+    "  [--provider-mode <mock-openai|live-frontier>]",
+    "  [--scenario <scenario-id>]",
+  ].join("\n");
+}
+
+function parseArgs(argv) {
+  const args = { providerMode: "mock-openai" };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (!args.samplesPath && !arg.startsWith("--")) {
+      args.samplesPath = arg;
+      continue;
+    }
+    if (arg === "--channel") {
+      args.channelId = argv[(index += 1)];
+      continue;
+    }
+    if (arg === "--spec") {
+      args.spec = argv[(index += 1)];
+      continue;
+    }
+    if (arg === "--version") {
+      args.version = argv[(index += 1)];
+      continue;
+    }
+    if (arg === "--provider-mode") {
+      args.providerMode = argv[(index += 1)];
+      continue;
+    }
+    if (arg === "--scenario") {
+      args.scenario = argv[(index += 1)];
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}\n${usage()}`);
+  }
+  if (!args.samplesPath || !args.channelId || !args.spec || !args.version) {
+    throw new Error(usage());
+  }
+  return args;
+}
+
+function requireObject(value, label) {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error(`${label} must be an object.`);
+  }
+  return value;
+}
+
+function requireString(value, label) {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(`${label} must be a non-empty string.`);
+  }
+  return value;
+}
+
+function requireNumber(value, label) {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new Error(`${label} must be a finite number.`);
+  }
+  return value;
+}
+
+function validateSummary(value) {
+  const summary = requireObject(value, "summary");
+  requireString(summary.startedAt, "summary.startedAt");
+  requireString(summary.finishedAt, "summary.finishedAt");
+  if (!Array.isArray(summary.scenarios)) {
+    throw new Error("summary.scenarios must be an array.");
+  }
+  const counts = requireObject(summary.counts, "summary.counts");
+  requireNumber(counts.total, "summary.counts.total");
+  requireNumber(counts.passed, "summary.counts.passed");
+  requireNumber(counts.failed, "summary.counts.failed");
+  return summary;
+}
+
+function safeRunLabel(input) {
+  return input.replace(/[^a-zA-Z0-9.-]+/gu, "_").replace(/^_+|_+$/gu, "");
+}
+
+function quantile(sorted, q) {
+  if (sorted.length === 0) {
+    return undefined;
+  }
+  const index = Math.min(sorted.length - 1, Math.max(0, Math.ceil(sorted.length * q) - 1));
+  return sorted[index];
+}
+
+function stats(samples) {
+  const sorted = [...samples].sort((left, right) => left - right);
+  const total = sorted.reduce((sum, value) => sum + value, 0);
+  return {
+    avgMs: sorted.length ? total / sorted.length : undefined,
+    p50Ms: quantile(sorted, 0.5),
+    p95Ms: quantile(sorted, 0.95),
+    maxMs: sorted.at(-1),
+  };
+}
+
+async function readJson(pathname) {
+  return JSON.parse(await fs.readFile(pathname, "utf8"));
+}
+
+async function readSampleEntries(samplesPath) {
+  const text = await fs.readFile(samplesPath, "utf8");
+  return text
+    .split("\n")
+    .filter(Boolean)
+    .map((line, index) => {
+      const [summaryPath, observedMessagesPath] = line.split("\t");
+      if (!summaryPath) {
+        throw new Error(`Invalid sample-paths line ${index + 1}: expected summary path.`);
+      }
+      return { summaryPath, observedMessagesPath };
+    });
+}
+
+async function existingRunIds(dataPath) {
+  try {
+    const text = await fs.readFile(dataPath, "utf8");
+    return new Set(
+      text
+        .split("\n")
+        .filter(Boolean)
+        .map((line) => JSON.parse(line).run?.id)
+        .filter(Boolean),
+    );
+  } catch (error) {
+    if (error?.code === "ENOENT") {
+      return new Set();
+    }
+    throw error;
+  }
+}
+
+function extractObservedRtt(observedMessages, scenarioId) {
+  if (!Array.isArray(observedMessages)) {
+    throw new Error("observed messages must be an array.");
+  }
+  const matched = observedMessages.find(
+    (message) =>
+      message?.scenarioId === scenarioId &&
+      message?.matchedScenario === true &&
+      typeof message.triggerTimestamp === "string" &&
+      typeof message.timestamp === "string",
+  );
+  if (!matched) {
+    return undefined;
+  }
+  const sentAtMs = Date.parse(matched.triggerTimestamp);
+  const repliedAtMs = Date.parse(matched.timestamp);
+  if (!Number.isFinite(sentAtMs) || !Number.isFinite(repliedAtMs)) {
+    return undefined;
+  }
+  const rttMs = Math.max(0, Math.round(repliedAtMs - sentAtMs));
+  return Number.isFinite(rttMs) ? rttMs : undefined;
+}
+
+function selectScenario(summary, scenarioId) {
+  const scenario = summary.scenarios.find((item) => item?.id === scenarioId);
+  if (!scenario) {
+    const available = summary.scenarios.map((item) => item?.id).filter(Boolean).join(", ");
+    throw new Error(`summary missing scenario ${scenarioId}; available: ${available || "<none>"}`);
+  }
+  return scenario;
+}
+
+async function readSample(entry, index, scenarioId) {
+  const summary = validateSummary(await readJson(path.resolve(entry.summaryPath)));
+  const scenario = selectScenario(summary, scenarioId);
+  let rttMs = typeof scenario.rttMs === "number" && Number.isFinite(scenario.rttMs) ? scenario.rttMs : undefined;
+  if (rttMs === undefined && entry.observedMessagesPath) {
+    rttMs = extractObservedRtt(await readJson(path.resolve(entry.observedMessagesPath)), scenarioId);
+  }
+  return {
+    index,
+    summary,
+    scenario: {
+      details: scenario.details,
+      id: scenario.id,
+      rttMs,
+      status: scenario.status === "pass" && rttMs !== undefined ? "pass" : "fail",
+      title: scenario.title,
+    },
+  };
+}
+
+function buildRunId(startedAt, channelId, scenarioId, spec) {
+  return [
+    startedAt.replaceAll(":", "").replaceAll(".", ""),
+    safeRunLabel(spec),
+    safeRunLabel(channelId),
+    safeRunLabel(scenarioId),
+    "rtt",
+  ].join("-");
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const channel = resolveChannelRttChannel(args.channelId);
+  const scenarioId = args.scenario ?? channel.defaultScenario;
+  const entries = await readSampleEntries(path.resolve(args.samplesPath));
+  if (entries.length === 0) {
+    throw new Error("No channel RTT samples to import.");
+  }
+
+  const samples = [];
+  for (let index = 0; index < entries.length; index += 1) {
+    samples.push(await readSample(entries[index], index + 1, scenarioId));
+  }
+
+  const startedAt = samples[0].summary.startedAt;
+  const finishedAt = samples.at(-1).summary.finishedAt;
+  const startedAtMs = Date.parse(startedAt);
+  const finishedAtMs = Date.parse(finishedAt);
+  if (!Number.isFinite(startedAtMs) || !Number.isFinite(finishedAtMs)) {
+    throw new Error("Channel RTT sample timestamps must be parseable.");
+  }
+
+  const dataPath = channelRttDataPath(channel.id);
+  const runId = buildRunId(startedAt, channel.id, scenarioId, args.spec);
+  const seen = await existingRunIds(dataPath);
+  if (seen.has(runId)) {
+    throw new Error(`Channel RTT run already imported: ${runId}`);
+  }
+
+  const warmSamples = samples.flatMap((sample) =>
+    sample.scenario.status === "pass" ? [sample.scenario.rttMs] : [],
+  );
+  const failedSamples = samples.length - warmSamples.length;
+  const runDir = path.join(channelRttRunsDir(channel.id), runId);
+  const resultPath = path.join(runDir, "result.json");
+  const result = {
+    channel: {
+      id: channel.id,
+      label: channel.label,
+      scenario: scenarioId,
+    },
+    package: {
+      spec: args.spec,
+      version: args.version,
+    },
+    run: {
+      id: runId,
+      startedAt,
+      finishedAt,
+      durationMs: finishedAtMs - startedAtMs,
+      status: failedSamples === 0 ? "pass" : "fail",
+    },
+    mode: {
+      providerMode: args.providerMode,
+      credentialSource: samples[0].summary.credentials?.source,
+      credentialRole: samples[0].summary.credentials?.role,
+    },
+    rtt: {
+      warmSamples,
+      failedSamples,
+      ...stats(warmSamples),
+    },
+    samples: samples.map((sample) => ({
+      index: sample.index,
+      status: sample.scenario.status,
+      ...(sample.scenario.rttMs === undefined ? {} : { rttMs: sample.scenario.rttMs }),
+      ...(sample.scenario.details ? { details: sample.scenario.details } : {}),
+    })),
+    artifacts: {
+      resultPath,
+    },
+  };
+
+  await fs.mkdir(runDir, { recursive: true });
+  await fs.writeFile(resultPath, `${JSON.stringify(result, null, 2)}\n`);
+  await fs.mkdir(path.dirname(dataPath), { recursive: true });
+  await fs.appendFile(dataPath, `${JSON.stringify(result)}\n`);
+  process.stdout.write(`imported ${runId}\n`);
+}
+
+main().catch((error) => {
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+  process.exitCode = 1;
+});

--- a/scripts/import-live-transport-rtt.test.mjs
+++ b/scripts/import-live-transport-rtt.test.mjs
@@ -31,6 +31,7 @@ async function readJsonl(pathname) {
 test("imports live transport summary RTT samples", async () => {
   const workspace = await makeWorkspace();
   const summaryPath = path.join(workspace, "sample-1", "slack-qa-summary.json");
+  const resourceMetricsPath = path.join(workspace, "sample-1", "resource-metrics.env");
   await writeJson(summaryPath, {
     credentials: { kind: "slack", role: "ci", source: "convex" },
     startedAt: "2026-05-16T00:00:00.000Z",
@@ -46,8 +47,9 @@ test("imports live transport summary RTT samples", async () => {
       },
     ],
   });
+  await fs.writeFile(resourceMetricsPath, "max_rss_kb=204800\nelapsed_seconds=2.5\n");
   const samplesPath = path.join(workspace, "samples.tsv");
-  await fs.writeFile(samplesPath, `${summaryPath}\n`);
+  await fs.writeFile(samplesPath, `${summaryPath}\t\t${resourceMetricsPath}\n`);
 
   await execFileAsync(
     process.execPath,
@@ -72,6 +74,9 @@ test("imports live transport summary RTT samples", async () => {
   assert.equal(row.run.status, "pass");
   assert.deepEqual(row.rtt.warmSamples, [321]);
   assert.equal(row.rtt.p50Ms, 321);
+  assert.deepEqual(row.resources.maxRssKbSamples, [204800]);
+  assert.equal(row.resources.maxRssKb.p50, 204800);
+  assert.deepEqual(row.resources.elapsedSecondsSamples, [2.5]);
 });
 
 test("falls back to observed message timestamps when summaries do not carry RTT", async () => {

--- a/scripts/import-live-transport-rtt.test.mjs
+++ b/scripts/import-live-transport-rtt.test.mjs
@@ -47,7 +47,7 @@ test("imports live transport summary RTT samples", async () => {
       },
     ],
   });
-  await fs.writeFile(resourceMetricsPath, "max_rss_kb=204800\nelapsed_seconds=2.5\n");
+  await fs.writeFile(resourceMetricsPath, "max_rss_kb=204800\nelapsed_seconds=2.5\nattempts=2\n");
   const samplesPath = path.join(workspace, "samples.tsv");
   await fs.writeFile(samplesPath, `${summaryPath}\t\t${resourceMetricsPath}\n`);
 
@@ -77,6 +77,10 @@ test("imports live transport summary RTT samples", async () => {
   assert.deepEqual(row.resources.maxRssKbSamples, [204800]);
   assert.equal(row.resources.maxRssKb.p50, 204800);
   assert.deepEqual(row.resources.elapsedSecondsSamples, [2.5]);
+  assert.deepEqual(row.polling.attemptSamples, [2]);
+  assert.equal(row.polling.retryCount, 1);
+  assert.equal(row.polling.maxAttempts, 2);
+  assert.equal(row.samples[0].attempts, 2);
 });
 
 test("falls back to observed message timestamps when summaries do not carry RTT", async () => {

--- a/scripts/import-live-transport-rtt.test.mjs
+++ b/scripts/import-live-transport-rtt.test.mjs
@@ -134,3 +134,50 @@ test("falls back to observed message timestamps when summaries do not carry RTT"
   assert.equal(row.run.status, "pass");
   assert.deepEqual(row.rtt.warmSamples, [456]);
 });
+
+test("can require imported channel samples to pass", async () => {
+  const workspace = await makeWorkspace();
+  const summaryPath = path.join(workspace, "sample-1", "slack-qa-summary.json");
+  await writeJson(summaryPath, {
+    credentials: { kind: "slack", role: "ci", source: "convex" },
+    startedAt: "2026-05-16T02:00:00.000Z",
+    finishedAt: "2026-05-16T02:00:05.000Z",
+    counts: { total: 1, passed: 0, failed: 1 },
+    scenarios: [
+      {
+        id: "slack-canary",
+        title: "Slack canary",
+        status: "fail",
+        details: "credential pool exhausted",
+      },
+    ],
+  });
+  const samplesPath = path.join(workspace, "samples.tsv");
+  await fs.writeFile(samplesPath, `${summaryPath}\n`);
+
+  await assert.rejects(
+    execFileAsync(
+      process.execPath,
+      [
+        IMPORT_SCRIPT,
+        samplesPath,
+        "--channel",
+        "slack",
+        "--spec",
+        "openclaw@main",
+        "--version",
+        "2026.5.16+abcdef1234",
+        "--provider-mode",
+        "mock-openai",
+        "--require-pass",
+      ],
+      { cwd: workspace },
+    ),
+    /Channel RTT run failed/u,
+  );
+
+  const [row] = await readJsonl(path.join(workspace, "data/channel-rtt/slack.jsonl"));
+  assert.equal(row.run.status, "fail");
+  assert.deepEqual(row.rtt.warmSamples, []);
+  assert.equal(row.rtt.failedSamples, 1);
+});

--- a/scripts/import-live-transport-rtt.test.mjs
+++ b/scripts/import-live-transport-rtt.test.mjs
@@ -1,0 +1,127 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import test from "node:test";
+
+const execFileAsync = promisify(execFile);
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const IMPORT_SCRIPT = path.join(REPO_ROOT, "scripts/import-live-transport-rtt.mjs");
+
+async function makeWorkspace() {
+  return await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-rtt-test-"));
+}
+
+async function writeJson(pathname, value) {
+  await fs.mkdir(path.dirname(pathname), { recursive: true });
+  await fs.writeFile(pathname, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+async function readJsonl(pathname) {
+  const text = await fs.readFile(pathname, "utf8");
+  return text
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+test("imports live transport summary RTT samples", async () => {
+  const workspace = await makeWorkspace();
+  const summaryPath = path.join(workspace, "sample-1", "slack-qa-summary.json");
+  await writeJson(summaryPath, {
+    credentials: { kind: "slack", role: "ci", source: "convex" },
+    startedAt: "2026-05-16T00:00:00.000Z",
+    finishedAt: "2026-05-16T00:00:02.000Z",
+    counts: { total: 1, passed: 1, failed: 0 },
+    scenarios: [
+      {
+        id: "slack-canary",
+        title: "Slack canary",
+        status: "pass",
+        details: "reply matched",
+        rttMs: 321,
+      },
+    ],
+  });
+  const samplesPath = path.join(workspace, "samples.tsv");
+  await fs.writeFile(samplesPath, `${summaryPath}\n`);
+
+  await execFileAsync(
+    process.execPath,
+    [
+      IMPORT_SCRIPT,
+      samplesPath,
+      "--channel",
+      "slack",
+      "--spec",
+      "openclaw@main",
+      "--version",
+      "2026.5.16+abcdef1234",
+      "--provider-mode",
+      "mock-openai",
+    ],
+    { cwd: workspace },
+  );
+
+  const [row] = await readJsonl(path.join(workspace, "data/channel-rtt/slack.jsonl"));
+  assert.equal(row.channel.id, "slack");
+  assert.equal(row.channel.scenario, "slack-canary");
+  assert.equal(row.run.status, "pass");
+  assert.deepEqual(row.rtt.warmSamples, [321]);
+  assert.equal(row.rtt.p50Ms, 321);
+});
+
+test("falls back to observed message timestamps when summaries do not carry RTT", async () => {
+  const workspace = await makeWorkspace();
+  const summaryPath = path.join(workspace, "sample-1", "discord-qa-summary.json");
+  const observedPath = path.join(workspace, "sample-1", "discord-qa-observed-messages.json");
+  await writeJson(summaryPath, {
+    credentials: { kind: "discord", role: "ci", source: "convex" },
+    startedAt: "2026-05-16T01:00:00.000Z",
+    finishedAt: "2026-05-16T01:00:05.000Z",
+    counts: { total: 1, passed: 1, failed: 0 },
+    scenarios: [
+      {
+        id: "discord-canary",
+        title: "Discord canary",
+        status: "pass",
+        details: "reply matched",
+      },
+    ],
+  });
+  await writeJson(observedPath, [
+    {
+      scenarioId: "discord-canary",
+      matchedScenario: true,
+      triggerTimestamp: "2026-05-16T01:00:01.000Z",
+      timestamp: "2026-05-16T01:00:01.456Z",
+    },
+  ]);
+  const samplesPath = path.join(workspace, "samples.tsv");
+  await fs.writeFile(samplesPath, `${summaryPath}\t${observedPath}\n`);
+
+  await execFileAsync(
+    process.execPath,
+    [
+      IMPORT_SCRIPT,
+      samplesPath,
+      "--channel",
+      "discord",
+      "--spec",
+      "openclaw@main",
+      "--version",
+      "2026.5.16+abcdef1234",
+      "--provider-mode",
+      "mock-openai",
+    ],
+    { cwd: workspace },
+  );
+
+  const [row] = await readJsonl(path.join(workspace, "data/channel-rtt/discord.jsonl"));
+  assert.equal(row.channel.id, "discord");
+  assert.equal(row.run.status, "pass");
+  assert.deepEqual(row.rtt.warmSamples, [456]);
+});

--- a/scripts/read-channel-rtt-rows.mjs
+++ b/scripts/read-channel-rtt-rows.mjs
@@ -1,0 +1,36 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { CHANNEL_RTT_DATA_DIR } from "./channel-rtt-config.mjs";
+
+export function compareChannelRttStartedAt(left, right) {
+  return String(left.run.startedAt).localeCompare(String(right.run.startedAt));
+}
+
+async function readJsonl(pathname) {
+  const text = await fs.readFile(pathname, "utf8");
+  return text
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+export async function readChannelRttRows() {
+  let entries = [];
+  try {
+    entries = await fs.readdir(CHANNEL_RTT_DATA_DIR, { withFileTypes: true });
+  } catch (error) {
+    if (error?.code === "ENOENT") {
+      return [];
+    }
+    throw error;
+  }
+
+  const rows = [];
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith(".jsonl")) {
+      continue;
+    }
+    rows.push(...(await readJsonl(path.join(CHANNEL_RTT_DATA_DIR, entry.name))));
+  }
+  return rows.sort(compareChannelRttStartedAt);
+}

--- a/scripts/update-readme.mjs
+++ b/scripts/update-readme.mjs
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises";
+import { readChannelRttRows } from "./read-channel-rtt-rows.mjs";
 import { readDiscordRttRows } from "./read-discord-rtt-rows.mjs";
 import { readRows } from "./read-rows.mjs";
 
@@ -9,6 +10,8 @@ const RELEASE_START = "<!-- release-sweep:start -->";
 const RELEASE_END = "<!-- release-sweep:end -->";
 const DISCORD_RELEASE_START = "<!-- discord-release-sweep:start -->";
 const DISCORD_RELEASE_END = "<!-- discord-release-sweep:end -->";
+const CHANNEL_RTT_START = "<!-- channel-rtt:start -->";
+const CHANNEL_RTT_END = "<!-- channel-rtt:end -->";
 const RELEASE_SPEC_RE =
   /^openclaw@[0-9]{4}\.[1-9][0-9]*\.[1-9][0-9]*(?:-beta\.[1-9][0-9]*)?$/u;
 const UPDATE_LATEST_MAIN_ONLY = process.argv.includes("--latest-main-only");
@@ -108,6 +111,39 @@ function releaseTableFor(rows, start, end) {
   ].join("\n");
 }
 
+function channelRttRows(rows) {
+  const byKey = new Map();
+  for (const row of rows) {
+    byKey.set(`${row.channel.id}\0${row.channel.scenario}\0${row.package.spec}`, row);
+  }
+  return [...byKey.values()].sort((left, right) => {
+    const channelDiff = String(left.channel.label).localeCompare(String(right.channel.label));
+    if (channelDiff !== 0) {
+      return channelDiff;
+    }
+    return String(right.run.startedAt).localeCompare(String(left.run.startedAt));
+  });
+}
+
+function channelRttTableFor(rows) {
+  const tableRows = channelRttRows(rows);
+  if (tableRows.length === 0) {
+    return [CHANNEL_RTT_START, "", "No channel RTT runs have been imported yet.", "", CHANNEL_RTT_END].join("\n");
+  }
+  return [
+    CHANNEL_RTT_START,
+    "",
+    "| Channel | Scenario | Version/ref | Result | Samples | p50 | p95 | Updated |",
+    "|---|---|---:|---:|---:|---:|---:|---:|",
+    ...tableRows.map(
+      (row) =>
+        `| ${row.channel.label} | \`${row.channel.scenario}\` | \`${formatVersion(row.package.version)}\` | ${resultLabel(row)} | ${sampleCount(row)} | ${formatMs(row.rtt.p50Ms)} | ${formatMs(row.rtt.p95Ms)} | \`${row.run.startedAt}\` |`,
+    ),
+    "",
+    CHANNEL_RTT_END,
+  ].join("\n");
+}
+
 function replaceMarked(readme, start, end, replacement) {
   const startIndex = readme.indexOf(start);
   const endIndex = readme.indexOf(end);
@@ -120,6 +156,7 @@ function replaceMarked(readme, start, end, replacement) {
 async function main() {
   const rows = await readRows();
   const discordRows = await readDiscordRttRows();
+  const channelRows = await readChannelRttRows();
   const latestMain = rows.filter((row) => row.package.spec === "openclaw@main").at(-1);
   const latestDiscordMain = discordRows
     .filter((row) => row.package.spec === "openclaw@main")
@@ -135,14 +172,19 @@ async function main() {
     ? withLatestMain
     : replaceMarked(
         replaceMarked(
-          withLatestMain,
-          RELEASE_START,
-          RELEASE_END,
-          releaseTableFor(rows, RELEASE_START, RELEASE_END),
+          replaceMarked(
+            withLatestMain,
+            RELEASE_START,
+            RELEASE_END,
+            releaseTableFor(rows, RELEASE_START, RELEASE_END),
+          ),
+          DISCORD_RELEASE_START,
+          DISCORD_RELEASE_END,
+          releaseTableFor(discordRows, DISCORD_RELEASE_START, DISCORD_RELEASE_END),
         ),
-        DISCORD_RELEASE_START,
-        DISCORD_RELEASE_END,
-        releaseTableFor(discordRows, DISCORD_RELEASE_START, DISCORD_RELEASE_END),
+        CHANNEL_RTT_START,
+        CHANNEL_RTT_END,
+        channelRttTableFor(channelRows),
       );
   await fs.writeFile(README_PATH, next);
 }

--- a/scripts/update-readme.mjs
+++ b/scripts/update-readme.mjs
@@ -20,6 +20,12 @@ function formatMs(value) {
   return typeof value === "number" ? `\`${Math.round(value).toLocaleString("en-US")}ms\`` : "-";
 }
 
+function formatRssKb(value) {
+  return typeof value === "number"
+    ? `\`${Math.round(value / 1024).toLocaleString("en-US")}MB\``
+    : "-";
+}
+
 function formatVersion(value) {
   return /^[0-9a-f]{40}$/u.test(value) ? value.slice(0, 10) : value;
 }
@@ -133,11 +139,11 @@ function channelRttTableFor(rows) {
   return [
     CHANNEL_RTT_START,
     "",
-    "| Channel | Scenario | Version/ref | Result | Samples | p50 | p95 | Updated |",
-    "|---|---|---:|---:|---:|---:|---:|---:|",
+    "| Channel | Scenario | Version/ref | Result | Samples | RTT p50 | RTT p95 | RSS p50 | RSS max | Updated |",
+    "|---|---|---:|---:|---:|---:|---:|---:|---:|---:|",
     ...tableRows.map(
       (row) =>
-        `| ${row.channel.label} | \`${row.channel.scenario}\` | \`${formatVersion(row.package.version)}\` | ${resultLabel(row)} | ${sampleCount(row)} | ${formatMs(row.rtt.p50Ms)} | ${formatMs(row.rtt.p95Ms)} | \`${row.run.startedAt}\` |`,
+        `| ${row.channel.label} | \`${row.channel.scenario}\` | \`${formatVersion(row.package.version)}\` | ${resultLabel(row)} | ${sampleCount(row)} | ${formatMs(row.rtt.p50Ms)} | ${formatMs(row.rtt.p95Ms)} | ${formatRssKb(row.resources?.maxRssKb?.p50)} | ${formatRssKb(row.resources?.maxRssKb?.max)} | \`${row.run.startedAt}\` |`,
     ),
     "",
     CHANNEL_RTT_END,

--- a/scripts/update-readme.mjs
+++ b/scripts/update-readme.mjs
@@ -38,6 +38,10 @@ function sampleCount(row) {
   return row.rtt.warmSamples?.length ?? 0;
 }
 
+function retryCount(row) {
+  return row.polling?.retryCount ?? 0;
+}
+
 function latestMainRow(label, row) {
   if (!row) {
     return `| ${label} | - | - | - | - | - | - |`;
@@ -139,11 +143,11 @@ function channelRttTableFor(rows) {
   return [
     CHANNEL_RTT_START,
     "",
-    "| Channel | Scenario | Version/ref | Result | Samples | RTT p50 | RTT p95 | RSS p50 | RSS max | Updated |",
-    "|---|---|---:|---:|---:|---:|---:|---:|---:|---:|",
+    "| Channel | Scenario | Version/ref | Result | Samples | Retries | RTT p50 | RTT p95 | RSS p50 | RSS max | Updated |",
+    "|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|",
     ...tableRows.map(
       (row) =>
-        `| ${row.channel.label} | \`${row.channel.scenario}\` | \`${formatVersion(row.package.version)}\` | ${resultLabel(row)} | ${sampleCount(row)} | ${formatMs(row.rtt.p50Ms)} | ${formatMs(row.rtt.p95Ms)} | ${formatRssKb(row.resources?.maxRssKb?.p50)} | ${formatRssKb(row.resources?.maxRssKb?.max)} | \`${row.run.startedAt}\` |`,
+        `| ${row.channel.label} | \`${row.channel.scenario}\` | \`${formatVersion(row.package.version)}\` | ${resultLabel(row)} | ${sampleCount(row)} | ${retryCount(row)} | ${formatMs(row.rtt.p50Ms)} | ${formatMs(row.rtt.p95Ms)} | ${formatRssKb(row.resources?.maxRssKb?.p50)} | ${formatRssKb(row.resources?.maxRssKb?.max)} | \`${row.run.startedAt}\` |`,
     ),
     "",
     CHANNEL_RTT_END,

--- a/scripts/update-readme.test.mjs
+++ b/scripts/update-readme.test.mjs
@@ -55,6 +55,11 @@ test("renders channel RTT and RSS metrics in the README channel table", async ()
         finishedAt: "2026-05-16T00:00:02.000Z",
         status: "pass",
       },
+      polling: {
+        attemptSamples: [1, 2],
+        retryCount: 1,
+        maxAttempts: 2,
+      },
       rtt: { warmSamples: [300, 400], p50Ms: 300, p95Ms: 400 },
       resources: {
         maxRssKbSamples: [204800, 307200],
@@ -66,9 +71,9 @@ test("renders channel RTT and RSS metrics in the README channel table", async ()
   await execFileAsync(process.execPath, [UPDATE_README_SCRIPT], { cwd: workspace });
 
   const readme = await fs.readFile(path.join(workspace, "README.md"), "utf8");
-  assert.match(readme, /\| Channel \| Scenario \| Version\/ref \| Result \| Samples \| RTT p50 \| RTT p95 \| RSS p50 \| RSS max \| Updated \|/u);
+  assert.match(readme, /\| Channel \| Scenario \| Version\/ref \| Result \| Samples \| Retries \| RTT p50 \| RTT p95 \| RSS p50 \| RSS max \| Updated \|/u);
   assert.match(
     readme,
-    /\| Slack \| `slack-canary` \| `2026\.5\.16\+abcdef1234` \| Pass \| 2 \| `300ms` \| `400ms` \| `200MB` \| `300MB` \| `2026-05-16T00:00:00\.000Z` \|/u,
+    /\| Slack \| `slack-canary` \| `2026\.5\.16\+abcdef1234` \| Pass \| 2 \| 1 \| `300ms` \| `400ms` \| `200MB` \| `300MB` \| `2026-05-16T00:00:00\.000Z` \|/u,
   );
 });

--- a/scripts/update-readme.test.mjs
+++ b/scripts/update-readme.test.mjs
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import test from "node:test";
+
+const execFileAsync = promisify(execFile);
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const UPDATE_README_SCRIPT = path.join(REPO_ROOT, "scripts/update-readme.mjs");
+
+async function makeWorkspace() {
+  return await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-rtt-readme-test-"));
+}
+
+async function writeJsonl(pathname, rows) {
+  await fs.mkdir(path.dirname(pathname), { recursive: true });
+  await fs.writeFile(pathname, `${rows.map((row) => JSON.stringify(row)).join("\n")}\n`);
+}
+
+test("renders channel RTT and RSS metrics in the README channel table", async () => {
+  const workspace = await makeWorkspace();
+  await fs.writeFile(
+    path.join(workspace, "README.md"),
+    [
+      "# OpenClaw RTT",
+      "",
+      "<!-- latest-main:start -->",
+      "old main",
+      "<!-- latest-main:end -->",
+      "",
+      "<!-- release-sweep:start -->",
+      "old release",
+      "<!-- release-sweep:end -->",
+      "",
+      "<!-- discord-release-sweep:start -->",
+      "old discord release",
+      "<!-- discord-release-sweep:end -->",
+      "",
+      "<!-- channel-rtt:start -->",
+      "old channel",
+      "<!-- channel-rtt:end -->",
+      "",
+    ].join("\n"),
+  );
+  await writeJsonl(path.join(workspace, "data/channel-rtt/slack.jsonl"), [
+    {
+      channel: { id: "slack", label: "Slack", scenario: "slack-canary" },
+      package: { spec: "openclaw@main", version: "2026.5.16+abcdef1234" },
+      run: {
+        id: "slack-run",
+        startedAt: "2026-05-16T00:00:00.000Z",
+        finishedAt: "2026-05-16T00:00:02.000Z",
+        status: "pass",
+      },
+      rtt: { warmSamples: [300, 400], p50Ms: 300, p95Ms: 400 },
+      resources: {
+        maxRssKbSamples: [204800, 307200],
+        maxRssKb: { p50: 204800, p95: 307200, max: 307200 },
+      },
+    },
+  ]);
+
+  await execFileAsync(process.execPath, [UPDATE_README_SCRIPT], { cwd: workspace });
+
+  const readme = await fs.readFile(path.join(workspace, "README.md"), "utf8");
+  assert.match(readme, /\| Channel \| Scenario \| Version\/ref \| Result \| Samples \| RTT p50 \| RTT p95 \| RSS p50 \| RSS max \| Updated \|/u);
+  assert.match(
+    readme,
+    /\| Slack \| `slack-canary` \| `2026\.5\.16\+abcdef1234` \| Pass \| 2 \| `300ms` \| `400ms` \| `200MB` \| `300MB` \| `2026-05-16T00:00:00\.000Z` \|/u,
+  );
+});

--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -81,6 +81,37 @@ function assertChannelRttRun(row, index) {
   if (row.rtt.warmSamples.some((sample) => typeof sample !== "number" || !Number.isFinite(sample))) {
     throw new Error(`Channel RTT row ${index} has invalid rtt.warmSamples`);
   }
+  if (row.resources !== undefined) {
+    if (typeof row.resources !== "object" || row.resources === null || Array.isArray(row.resources)) {
+      throw new Error(`Channel RTT row ${index} has invalid resources`);
+    }
+    if (
+      row.resources.maxRssKbSamples !== undefined &&
+      (!Array.isArray(row.resources.maxRssKbSamples) ||
+        row.resources.maxRssKbSamples.some(
+          (sample) => typeof sample !== "number" || !Number.isFinite(sample),
+        ))
+    ) {
+      throw new Error(`Channel RTT row ${index} has invalid resources.maxRssKbSamples`);
+    }
+    for (const [metricName, stats] of Object.entries({
+      maxRssKb: row.resources.maxRssKb,
+      elapsedSeconds: row.resources.elapsedSeconds,
+    })) {
+      if (stats === undefined) {
+        continue;
+      }
+      if (typeof stats !== "object" || stats === null || Array.isArray(stats)) {
+        throw new Error(`Channel RTT row ${index} has invalid resources.${metricName}`);
+      }
+      for (const statName of ["avg", "p50", "p95", "max"]) {
+        const value = stats[statName];
+        if (value !== undefined && (typeof value !== "number" || !Number.isFinite(value))) {
+          throw new Error(`Channel RTT row ${index} has invalid resources.${metricName}.${statName}`);
+        }
+      }
+    }
+  }
 }
 
 async function validateJsonl(pathname, label, assertRow) {

--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { readChannelRttRows } from "./read-channel-rtt-rows.mjs";
 
 const DATA_PATH = path.resolve("data/rtt.jsonl");
 const DISCORD_RTT_DATA_PATH = path.resolve("data/discord-rtt.jsonl");
@@ -49,6 +50,39 @@ function assertDiscordRttRun(row, index) {
   }
 }
 
+function assertChannelRttRun(row, index) {
+  if (typeof row !== "object" || row === null) {
+    throw new Error(`Channel RTT row ${index} must be an object`);
+  }
+  if (typeof row.channel?.id !== "string") {
+    throw new Error(`Channel RTT row ${index} missing channel.id`);
+  }
+  if (typeof row.channel?.label !== "string") {
+    throw new Error(`Channel RTT row ${index} missing channel.label`);
+  }
+  if (typeof row.channel?.scenario !== "string") {
+    throw new Error(`Channel RTT row ${index} missing channel.scenario`);
+  }
+  if (typeof row.package?.spec !== "string") {
+    throw new Error(`Channel RTT row ${index} missing package.spec`);
+  }
+  if (typeof row.package?.version !== "string") {
+    throw new Error(`Channel RTT row ${index} missing package.version`);
+  }
+  if (typeof row.run?.id !== "string") {
+    throw new Error(`Channel RTT row ${index} missing run.id`);
+  }
+  if (row.run.status !== "pass" && row.run.status !== "fail") {
+    throw new Error(`Channel RTT row ${index} has invalid run.status`);
+  }
+  if (!Array.isArray(row.rtt?.warmSamples)) {
+    throw new Error(`Channel RTT row ${index} missing rtt.warmSamples`);
+  }
+  if (row.rtt.warmSamples.some((sample) => typeof sample !== "number" || !Number.isFinite(sample))) {
+    throw new Error(`Channel RTT row ${index} has invalid rtt.warmSamples`);
+  }
+}
+
 async function validateJsonl(pathname, label, assertRow) {
   let text = "";
   try {
@@ -74,9 +108,23 @@ async function validateJsonl(pathname, label, assertRow) {
   process.stdout.write(`ok: ${lines.length} ${label} rows\n`);
 }
 
+async function validateChannelRttRows() {
+  const rows = await readChannelRttRows();
+  const seen = new Set();
+  rows.forEach((row, index) => {
+    assertChannelRttRun(row, index + 1);
+    if (seen.has(row.run.id)) {
+      throw new Error(`duplicate Channel RTT run id: ${row.run.id}`);
+    }
+    seen.add(row.run.id);
+  });
+  process.stdout.write(`ok: ${rows.length} Channel RTT rows\n`);
+}
+
 async function main() {
   await validateJsonl(DATA_PATH, "RTT", assertRun);
   await validateJsonl(DISCORD_RTT_DATA_PATH, "Discord RTT", assertDiscordRttRun);
+  await validateChannelRttRows();
 }
 
 main().catch((error) => {

--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -75,6 +75,28 @@ function assertChannelRttRun(row, index) {
   if (row.run.status !== "pass" && row.run.status !== "fail") {
     throw new Error(`Channel RTT row ${index} has invalid run.status`);
   }
+  if (row.polling !== undefined) {
+    if (typeof row.polling !== "object" || row.polling === null || Array.isArray(row.polling)) {
+      throw new Error(`Channel RTT row ${index} has invalid polling`);
+    }
+    if (
+      row.polling.attemptSamples !== undefined &&
+      (!Array.isArray(row.polling.attemptSamples) ||
+        row.polling.attemptSamples.some(
+          (sample) => !Number.isInteger(sample) || sample < 1,
+        ))
+    ) {
+      throw new Error(`Channel RTT row ${index} has invalid polling.attemptSamples`);
+    }
+    const retryCount = row.polling.retryCount;
+    if (retryCount !== undefined && (!Number.isInteger(retryCount) || retryCount < 0)) {
+      throw new Error(`Channel RTT row ${index} has invalid polling.retryCount`);
+    }
+    const maxAttempts = row.polling.maxAttempts;
+    if (maxAttempts !== undefined && (!Number.isInteger(maxAttempts) || maxAttempts < 1)) {
+      throw new Error(`Channel RTT row ${index} has invalid polling.maxAttempts`);
+    }
+  }
   if (!Array.isArray(row.rtt?.warmSamples)) {
     throw new Error(`Channel RTT row ${index} missing rtt.warmSamples`);
   }


### PR DESCRIPTION
## Summary

- Adds a generic live-transport channel RTT importer for OpenClaw QA summaries, including summary-native RTT fields, observed-message timestamp fallback, per-sample resource metrics, and retry/attempt telemetry.
- Adds Slack and WhatsApp main RTT scheduling through a serialized Blacksmith workflow, plus a PR-safe three-sample live proof trigger for channel-lane changes.
- Adds README dashboard generation for future channel rows with samples, retries, RTT p50/p95, and RSS p50/max.
- Adds PR CI, CodeQL, Dependabot for Actions, CI cache, metadata redaction on live QA artifacts, disables persisted credentials for secondary OpenClaw checkouts, and updates artifact upload to `actions/upload-artifact@v7.0.1`.
- Documents the channel expansion contract and recommended next-channel order in docs/channel-expansion.md.

## Verification

- `npm test`
- `npm run check`
- `actionlint -no-color .github/workflows/*.yml`
- `ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].each { |f| YAML.load_file(f); puts "ok #{f}" }'`
- `git diff --check`
- CI run `25960800934`: success on `22500c9b16884bdf5e85449b48702757cc339854`
- CodeQL run `25960800906`: success on `22500c9b16884bdf5e85449b48702757cc339854`
- Main Channel RTT run `25960800917`: success on `22500c9b16884bdf5e85449b48702757cc339854`

## Real behavior proof

Behavior addressed: new channel RTT lane imports real OpenClaw QA channel summaries, tracks RSS and retry telemetry, fails PR proof on failed imported samples, and renders channel rows without committing PR proof data.

Real environment tested: GitHub Actions on `blacksmith-32vcpu-ubuntu-2404`, OpenClaw `main`, Convex-managed CI credentials, `mock-openai`, real Slack and WhatsApp channel QA transports.

Exact steps or command run after this patch: PR-triggered `Main Channel RTT` workflow on head SHA `22500c9b16884bdf5e85449b48702757cc339854`, three samples per channel, `CHANNEL_RTT_MAX_ATTEMPTS=3`, `--credential-source convex`, `--credential-role ci`, and importer `--require-pass`.

Evidence after fix: Slack job `76315669459` imported `slack-canary` for OpenClaw `2026.5.17+210ff7d318`; WhatsApp job `76315669456` imported `whatsapp-canary` for OpenClaw `2026.5.17+210ff7d318`. Downloaded artifacts from run `25960800917` were re-imported in a temp directory and validated with README regeneration.

Observed result after fix: Slack passed 3/3 with RTT samples `5463ms`, `4256ms`, `4581ms`, RSS max samples `7129808KB`, `712848KB`, `696372KB`, `0` retries, table p50/p95 `4581ms`/`5463ms`, and table RSS p50/max `696MB`/`6963MB`. WhatsApp passed 3/3 with RTT samples `8099ms`, `8527ms`, `8870ms`, RSS max samples `9174104KB`, `1263836KB`, `1143140KB`, `0` retries, table p50/p95 `8527ms`/`8870ms`, and table RSS p50/max `1234MB`/`8959MB`. Temp artifact import produced `ok: 2 Channel RTT rows` and rendered Slack/WhatsApp README rows.

What was not tested: scheduled 20-sample data commit to `main`; that path is the same workflow with PR commit skipping disabled, and `workflow_dispatch` becomes available once the new workflow exists on the default branch. Future channels beyond Slack and WhatsApp still need a matching OpenClaw `pnpm openclaw qa <channel>` runner plus CI-safe Convex credentials before they can be claimed live-proven.

## Notes

- Existing Telegram and Discord data files are intentionally left in place. The new channel lane starts with new data under `data/channel-rtt/<channel>.jsonl`.
- A prior run exposed a false-green risk when Slack Convex credentials were exhausted; the final patch fixes that by requiring imported channel samples to pass before the workflow can go green.


## Temporary PR Proof

- Temporary PR: https://github.com/openclaw/openclaw-rtt/pull/6
- Temporary head: `69f8a91b7a0cd83cf2fac90718ce7affc93ff469`
- Base under test: `rtt-channel-ci-hardening` at `22500c9b16884bdf5e85449b48702757cc339854`
- CI run `25960957339`: success
- CodeQL run `25960957349`: success
- Main Channel RTT run `25960957348`: success
- Slack job `76316073605`: real Convex E2E, 3/3 pass, RTT p50/p95 `4560ms`/`6356ms`, retries `0`
- WhatsApp job `76316073597`: real Convex E2E, 3/3 pass, RTT p50/p95 `8498ms`/`8532ms`, retries `0`
- Temp artifact import produced `ok: 2 Channel RTT rows` and rendered Slack/WhatsApp README rows with RTT/RSS columns.
