### PR TITLE
test(rtt): temporary channel proof

### DIFF
--- a/.github/workflows/main-channel-rtt.yml
+++ b/.github/workflows/main-channel-rtt.yml
@@ -1,5 +1,6 @@
 name: Main Channel RTT
 
+# Temporary PR proof marker: exercises the channel RTT workflow from a throwaway branch.
 on:
   schedule:
     - cron: "45 */6 * * *"


### PR DESCRIPTION
## Summary

Temporary verification PR into `rtt-channel-ci-hardening`.

This intentionally adds a no-op workflow comment so GitHub runs the PR-only CI and live channel RTT checks against the branch before PR #5 lands. This PR is not intended to merge.

## Verification

- `npm test`
- `npm run check`
- `actionlint -no-color .github/workflows/*.yml`
- `ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].each { |f| YAML.load_file(f); puts "ok #{f}" }'`
- `git diff --check`
