### PR TITLE
ci(rtt): serialize report writers

### DIFF
--- a/.github/workflows/main-channel-rtt.yml
+++ b/.github/workflows/main-channel-rtt.yml
@@ -27,7 +27,7 @@ permissions:
   contents: write
 
 concurrency:
-  group: main-channel-rtt
+  group: rtt-report-writer-${{ github.event_name == 'pull_request' && github.run_id || github.ref }}
   cancel-in-progress: false
 
 env:

--- a/.github/workflows/main-discord-rtt.yml
+++ b/.github/workflows/main-discord-rtt.yml
@@ -15,7 +15,7 @@ permissions:
   contents: write
 
 concurrency:
-  group: main-discord-rtt
+  group: rtt-report-writer-${{ github.ref }}
   cancel-in-progress: false
 
 env:
@@ -165,6 +165,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          git pull --rebase origin main
           node scripts/import-discord-rtt.mjs "${{ steps.discord_rtt.outputs.sample_paths }}" \
             --spec openclaw@main \
             --version "${{ steps.openclaw_ref.outputs.version }}" \

--- a/.github/workflows/main-rtt.yml
+++ b/.github/workflows/main-rtt.yml
@@ -9,7 +9,7 @@ permissions:
   contents: write
 
 concurrency:
-  group: main-rtt
+  group: rtt-report-writer-${{ github.ref }}
   cancel-in-progress: false
 
 env:
@@ -125,6 +125,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          git pull --rebase origin main
           node scripts/import-result.mjs "${{ steps.rtt.outputs.result_path }}"
           node scripts/update-readme.mjs
           node scripts/validate.mjs

--- a/.github/workflows/stable-release-rtt.yml
+++ b/.github/workflows/stable-release-rtt.yml
@@ -9,7 +9,7 @@ permissions:
   contents: write
 
 concurrency:
-  group: release-rtt
+  group: rtt-report-writer-${{ github.ref }}
   cancel-in-progress: false
 
 env:
@@ -135,6 +135,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          git pull --rebase origin main
           while IFS= read -r result_path; do
             node scripts/import-result.mjs "$result_path"
           done <"${{ steps.rtt.outputs.result_paths }}"


### PR DESCRIPTION
## Summary
- serialize report-writing workflows on a shared ref-scoped concurrency group
- rebase main, Discord, and release data imports before regenerating README and committing results
- keep pull-request channel proof isolated from main report-writer locking

## Verification
- `git diff --check`
