### PR TITLE
ci(rtt): add Discord release sweep

### DIFF
--- a/.github/workflows/stable-release-discord-rtt.yml
+++ b/.github/workflows/stable-release-discord-rtt.yml
@@ -1,0 +1,238 @@
+name: Release Discord RTT
+
+on:
+  schedule:
+    - cron: "45 */6 * * *"
+  workflow_dispatch:
+    inputs:
+      samples:
+        description: Number of Discord canary RTT samples
+        required: false
+        default: "20"
+        type: string
+
+permissions:
+  contents: write
+
+concurrency:
+  group: rtt-report-writer-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+  NODE_VERSION: "24.x"
+  PNPM_VERSION: "10.33.0"
+
+jobs:
+  resolve:
+    name: Resolve OpenClaw Discord release packages
+    runs-on: ubuntu-24.04
+    outputs:
+      anchor: ${{ steps.release.outputs.anchor }}
+      matrix: ${{ steps.release.outputs.matrix }}
+      reason: ${{ steps.release.outputs.reason }}
+      should_run: ${{ steps.release.outputs.should_run }}
+    steps:
+      - name: Checkout RTT tracker
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Resolve OpenClaw Discord packages
+        id: release
+        shell: bash
+        run: |
+          set -euo pipefail
+          node scripts/resolve-openclaw-discord-package.mjs
+
+      - name: Report skipped package
+        if: steps.release.outputs.should_run != 'true'
+        run: |
+          echo "No new Discord release versions to measure after ${{ steps.release.outputs.anchor }} (${{ steps.release.outputs.reason }})"
+
+  measure:
+    name: Measure OpenClaw Discord release RTT
+    needs: resolve
+    if: needs.resolve.outputs.should_run == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 120
+    environment: qa-live-shared
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix:
+        package: ${{ fromJSON(needs.resolve.outputs.matrix) }}
+    steps:
+      - name: Checkout RTT tracker
+        uses: actions/checkout@v6
+        with:
+          path: openclaw-rtt
+          fetch-depth: 0
+
+      - name: Checkout OpenClaw release
+        uses: actions/checkout@v6
+        with:
+          repository: openclaw/openclaw
+          ref: ${{ matrix.package.tag }}
+          path: openclaw
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Setup pnpm
+        shell: bash
+        run: |
+          set -euo pipefail
+          corepack enable
+          corepack prepare "pnpm@${PNPM_VERSION}" --activate
+
+      - name: Locate pnpm store
+        id: pnpm-store
+        working-directory: openclaw
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "path=$(pnpm store path --silent)" >>"$GITHUB_OUTPUT"
+
+      - name: Restore pnpm store
+        uses: actions/cache@v5
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: openclaw-release-discord-rtt-pnpm-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('openclaw/pnpm-lock.yaml') }}
+          restore-keys: |
+            openclaw-release-discord-rtt-pnpm-${{ runner.os }}-${{ runner.arch }}-
+
+      - name: Install OpenClaw dependencies
+        working-directory: openclaw
+        shell: bash
+        run: |
+          set -euo pipefail
+          time pnpm install --frozen-lockfile --prefer-offline --ignore-scripts=false --config.engine-strict=false --config.enable-pre-post-scripts=true --config.side-effects-cache=true
+
+      - name: Verify OpenClaw release ref
+        working-directory: openclaw
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="$(node -p "require('./package.json').version")"
+          if [[ "$version" != "${{ matrix.package.version }}" ]]; then
+            echo "OpenClaw package version mismatch: expected ${{ matrix.package.version }}, got ${version}" >&2
+            exit 1
+          fi
+
+      - name: Build private QA runtime
+        working-directory: openclaw
+        env:
+          NODE_OPTIONS: --max-old-space-size=8192
+        shell: bash
+        run: |
+          set -euo pipefail
+          time pnpm build
+
+      - name: Run Discord RTT samples
+        id: discord_rtt
+        working-directory: openclaw
+        env:
+          OPENCLAW_QA_CONVEX_SITE_URL: ${{ secrets.OPENCLAW_QA_CONVEX_SITE_URL }}
+          OPENCLAW_QA_CONVEX_SECRET_CI: ${{ secrets.OPENCLAW_QA_CONVEX_SECRET_CI }}
+          OPENCLAW_QA_CREDENTIAL_ACQUIRE_TIMEOUT_MS: "180000"
+          OPENCLAW_QA_CREDENTIAL_HTTP_TIMEOUT_MS: "60000"
+          OPENCLAW_QA_REDACT_PUBLIC_METADATA: "1"
+          INPUT_SAMPLES: ${{ github.event_name == 'workflow_dispatch' && inputs.samples || '20' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          samples="${INPUT_SAMPLES:-20}"
+          if ! [[ "$samples" =~ ^[1-9][0-9]*$ ]]; then
+            echo "samples must be a positive integer, got: $samples" >&2
+            exit 1
+          fi
+
+          output_root=".artifacts/qa-e2e/discord-release-rtt-${{ matrix.package.version }}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          sample_paths="$RUNNER_TEMP/openclaw-discord-release-rtt-samples.tsv"
+          : >"$sample_paths"
+          echo "output_root=${output_root}" >>"$GITHUB_OUTPUT"
+          echo "sample_paths=${sample_paths}" >>"$GITHUB_OUTPUT"
+
+          for sample in $(seq 1 "$samples"); do
+            output_dir="${output_root}/sample-${sample}"
+            summary_path="${output_dir}/discord-qa-summary.json"
+            observed_path="${output_dir}/discord-qa-observed-messages.json"
+            status=1
+            for attempt in 1 2 3; do
+              rm -rf "$output_dir"
+              mkdir -p "$output_dir"
+              set +e
+              pnpm openclaw qa discord \
+                --repo-root . \
+                --output-dir "${output_dir}" \
+                --provider-mode mock-openai \
+                --model mock-openai/gpt-5.5 \
+                --alt-model mock-openai/gpt-5.5-alt \
+                --fast \
+                --credential-source convex \
+                --credential-role ci \
+                --scenario discord-canary
+              status="$?"
+              set -e
+              if [[ -f "$summary_path" && -f "$observed_path" ]]; then
+                break
+              fi
+              if [[ "$attempt" -lt 3 ]]; then
+                sleep $((attempt * 15))
+              fi
+            done
+            if [[ ! -f "$summary_path" || ! -f "$observed_path" ]]; then
+              echo "No Discord QA artifacts produced for sample ${sample}." >&2
+              exit "$status"
+            fi
+            printf '%s\t%s\n' "${PWD}/${summary_path}" "${PWD}/${observed_path}" >>"$sample_paths"
+          done
+
+      - name: Import Discord RTT result
+        working-directory: openclaw-rtt
+        shell: bash
+        run: |
+          set -euo pipefail
+          git pull --rebase origin main
+          node scripts/import-discord-rtt.mjs "${{ steps.discord_rtt.outputs.sample_paths }}" \
+            --spec "${{ matrix.package.spec }}" \
+            --version "${{ matrix.package.version }}" \
+            --provider-mode mock-openai
+          node scripts/update-readme.mjs
+          node scripts/validate.mjs
+          node scripts/discord-rtt-summary.mjs
+
+      - name: Upload Discord RTT artifacts
+        if: always()
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: release-discord-rtt-${{ matrix.package.version }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: openclaw/.artifacts/qa-e2e/discord-release-rtt-${{ matrix.package.version }}-${{ github.run_id }}-${{ github.run_attempt }}
+          retention-days: 14
+          if-no-files-found: warn
+
+      - name: Commit result
+        working-directory: openclaw-rtt
+        shell: bash
+        run: |
+          set -euo pipefail
+          if git diff --quiet --exit-code; then
+            echo "No Discord release RTT changes to commit."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add README.md data/discord-rtt.jsonl discord-runs/
+          git commit -m "data: record discord release rtt"
+          git push

--- a/scripts/resolve-openclaw-discord-package.mjs
+++ b/scripts/resolve-openclaw-discord-package.mjs
@@ -1,0 +1,110 @@
+import { execFile } from "node:child_process";
+import fs from "node:fs/promises";
+import { promisify } from "node:util";
+import { readDiscordRttRows } from "./read-discord-rtt-rows.mjs";
+import { readRows } from "./read-rows.mjs";
+
+const execFileAsync = promisify(execFile);
+const STABLE_VERSION_RE = /^([0-9]{4})\.([1-9][0-9]*)\.([1-9][0-9]*)$/u;
+const BETA_VERSION_RE = /^([0-9]{4})\.([1-9][0-9]*)\.([1-9][0-9]*)-beta\.([1-9][0-9]*)$/u;
+const RELEASE_SPEC_RE =
+  /^openclaw@[0-9]{4}\.[1-9][0-9]*\.[1-9][0-9]*(?:-beta\.[1-9][0-9]*)?$/u;
+
+function parseVersion(version) {
+  const stableMatch = STABLE_VERSION_RE.exec(version);
+  if (stableMatch) {
+    return [...stableMatch.slice(1).map(Number), Number.MAX_SAFE_INTEGER];
+  }
+
+  const betaMatch = BETA_VERSION_RE.exec(version);
+  if (betaMatch) {
+    return betaMatch.slice(1).map(Number);
+  }
+
+  return undefined;
+}
+
+function compareVersions(left, right) {
+  const leftParts = parseVersion(left);
+  const rightParts = parseVersion(right);
+  if (!leftParts || !rightParts) {
+    throw new Error(`Cannot compare unsupported versions: ${left}, ${right}`);
+  }
+  for (let index = 0; index < leftParts.length; index += 1) {
+    const diff = leftParts[index] - rightParts[index];
+    if (diff !== 0) {
+      return diff;
+    }
+  }
+  return 0;
+}
+
+async function npmVersions() {
+  const { stdout } = await execFileAsync("npm", ["view", "openclaw", "versions", "--json"], {
+    timeout: 30_000,
+  });
+  const parsed = JSON.parse(stdout);
+  if (!Array.isArray(parsed)) {
+    throw new Error("npm view openclaw versions --json must return an array.");
+  }
+  return parsed;
+}
+
+function latestReleaseVersion(rows) {
+  return rows
+    .map((row) => row.package?.version)
+    .filter((version) => typeof version === "string" && parseVersion(version))
+    .sort(compareVersions)
+    .at(-1);
+}
+
+function latestStableVersion(rows) {
+  return rows
+    .map((row) => row.package?.version)
+    .filter((version) => typeof version === "string" && STABLE_VERSION_RE.test(version))
+    .sort(compareVersions)
+    .at(-1);
+}
+
+function releaseRows(rows) {
+  return rows.filter(
+    (row) =>
+      typeof row.package?.spec === "string" &&
+      RELEASE_SPEC_RE.test(row.package.spec) &&
+      typeof row.package?.version === "string" &&
+      parseVersion(row.package.version),
+  );
+}
+
+function writeOutput(values) {
+  const lines = Object.entries(values).map(([key, value]) => `${key}=${value}`);
+  if (process.env.GITHUB_OUTPUT) {
+    return fs.appendFile(process.env.GITHUB_OUTPUT, `${lines.join("\n")}\n`);
+  }
+  process.stdout.write(`${lines.join("\n")}\n`);
+}
+
+const discordRows = releaseRows(await readDiscordRttRows());
+const baselineRows = releaseRows(await readRows());
+const anchor = latestReleaseVersion(discordRows) ?? latestStableVersion(baselineRows);
+if (!anchor) {
+  throw new Error("No measured openclaw release baseline found.");
+}
+
+const measured = new Set(discordRows.map((row) => `${row.package.spec}\0${row.package.version}`));
+const queue = (await npmVersions())
+  .filter((version) => typeof version === "string" && parseVersion(version))
+  .filter((version) => compareVersions(version, anchor) > 0)
+  .map((version) => ({ version, spec: `openclaw@${version}`, tag: `v${version}` }))
+  .filter((pkg) => !measured.has(`${pkg.spec}\0${pkg.version}`))
+  .sort((left, right) => compareVersions(left.version, right.version));
+
+await writeOutput({
+  anchor,
+  count: String(queue.length),
+  specs: queue.map((pkg) => pkg.spec).join(" "),
+  versions: queue.map((pkg) => pkg.version).join(" "),
+  matrix: JSON.stringify(queue),
+  should_run: queue.length > 0 ? "true" : "false",
+  reason: queue.length > 0 ? "new-discord-release-versions" : "no-new-discord-release-versions",
+});


### PR DESCRIPTION
## Summary
- add a Discord release RTT resolver that queues new npm release versions without recomputing already imported Discord release rows
- add a scheduled/manual Release Discord RTT workflow that checks out the matching OpenClaw release tag, runs the Convex-backed Discord canary QA, imports rows, and updates the README report

## Verification
- `actionlint .github/workflows/stable-release-discord-rtt.yml`
- `node --check scripts/*.mjs`
- `node --test scripts/*.test.mjs`
- `node scripts/resolve-openclaw-discord-package.mjs`
- `node scripts/validate.mjs && node scripts/update-readme.mjs && git diff --exit-code README.md && git diff --check`

Behavior addressed: fills the missing Discord release-report automation path instead of leaving that README section permanently empty.
Real environment tested: local resolver/check/test validation; live Discord E2E will run through the new GitHub Actions workflow after merge or manual dispatch.
Exact steps or command run after this patch: listed above.
Evidence after fix: resolver currently queues `openclaw@2026.5.14-beta.1`, `openclaw@2026.5.14-beta.2`, `openclaw@2026.5.16-beta.1`, and `openclaw@2026.5.16-beta.2` from anchor `2026.5.12`; local data validation reports `ok: 98 RTT rows`, `ok: 5 Discord RTT rows`, `ok: 2 Channel RTT rows`.
Observed result after fix: workflow syntax and local report rendering are clean.
What was not tested: the new release Discord workflow has not yet been run against Convex credentials on GitHub Actions.
