### PR TITLE
fix(import): ingest summary rtt and gateway rss metrics

### DIFF
--- a/scripts/import-discord-rtt.mjs
+++ b/scripts/import-discord-rtt.mjs
@@ -169,6 +169,15 @@ function extractSummaryDurationRtt(summary) {
   return Number.isFinite(rttMs) ? rttMs : undefined;
 }
 
+function extractSummaryScenarioRtt(scenario) {
+  if (scenario?.status !== "pass") {
+    return undefined;
+  }
+  return typeof scenario.rttMs === "number" && Number.isFinite(scenario.rttMs)
+    ? Math.max(0, Math.round(scenario.rttMs))
+    : undefined;
+}
+
 async function readSample(entry, index) {
   const summary = validateSummary(await readJson(path.resolve(entry.summaryPath)));
   const observedMessages = await readJson(path.resolve(entry.observedMessagesPath));
@@ -176,15 +185,26 @@ async function readSample(entry, index) {
     ? await readResourceMetrics(path.resolve(entry.resourceMetricsPath))
     : undefined;
   const scenario = summary.scenarios.find((item) => item?.id === "discord-canary");
+  const summaryRttMs = extractSummaryScenarioRtt(scenario);
   const observedRttMs = extractCanaryRtt(observedMessages);
   const rttMs =
-    observedRttMs ?? (scenario?.status === "pass" ? extractSummaryDurationRtt(summary) : undefined);
+    summaryRttMs ??
+    observedRttMs ??
+    (scenario?.status === "pass" ? extractSummaryDurationRtt(summary) : undefined);
+  const rttSource =
+    summaryRttMs !== undefined
+      ? "summary-rtt"
+      : observedRttMs !== undefined
+        ? "observed-message"
+        : rttMs !== undefined
+          ? "summary-duration"
+          : undefined;
   return {
     index,
     summary,
     status: scenario?.status === "pass" && rttMs !== undefined ? "pass" : "fail",
     rttMs,
-    rttSource: observedRttMs === undefined && rttMs !== undefined ? "summary-duration" : "observed-message",
+    rttSource,
     details: scenario?.details,
     resources,
   };

--- a/scripts/import-discord-rtt.mjs
+++ b/scripts/import-discord-rtt.mjs
@@ -178,6 +178,25 @@ function extractSummaryScenarioRtt(scenario) {
     : undefined;
 }
 
+function extractGatewayResourceMetrics(summary) {
+  const metrics = summary.metrics;
+  if (!metrics || typeof metrics !== "object" || Array.isArray(metrics)) {
+    return {};
+  }
+  return Object.fromEntries(
+    [
+      "gatewayProcessRssStartBytes",
+      "gatewayProcessRssEndBytes",
+      "gatewayProcessRssDeltaBytes",
+      "gatewayProcessRssPeakBytes",
+      "gatewayProcessRssPeakDeltaBytes",
+    ].flatMap((metricName) => {
+      const value = metrics[metricName];
+      return typeof value === "number" && Number.isFinite(value) ? [[metricName, value]] : [];
+    }),
+  );
+}
+
 async function readSample(entry, index) {
   const summary = validateSummary(await readJson(path.resolve(entry.summaryPath)));
   const observedMessages = await readJson(path.resolve(entry.observedMessagesPath));
@@ -206,7 +225,10 @@ async function readSample(entry, index) {
     rttMs,
     rttSource,
     details: scenario?.details,
-    resources,
+    resources: {
+      ...(resources ?? {}),
+      ...extractGatewayResourceMetrics(summary),
+    },
   };
 }
 

--- a/scripts/import-discord-rtt.test.mjs
+++ b/scripts/import-discord-rtt.test.mjs
@@ -65,6 +65,13 @@ test("imports Discord resource metrics without changing RTT stats", async () => 
       startedAt: "2026-05-16T00:00:00.000Z",
       finishedAt: "2026-05-16T00:00:45.000Z",
       counts: { total: 1, passed: 1, failed: 0 },
+      metrics: {
+        gatewayProcessRssStartBytes: 100_000_000,
+        gatewayProcessRssEndBytes: 125_000_000,
+        gatewayProcessRssDeltaBytes: 25_000_000,
+        gatewayProcessRssPeakBytes: 140_000_000,
+        gatewayProcessRssPeakDeltaBytes: 40_000_000,
+      },
       scenarios: [{ id: "discord-canary", status: "pass" }],
       credentials: { source: "convex", role: "ci" },
     })}\n`,
@@ -116,6 +123,9 @@ test("imports Discord resource metrics without changing RTT stats", async () => 
   assert.deepEqual(row.resources.maxRssKbSamples, [204800]);
   assert.equal(row.resources.maxRssKb.p50, 204800);
   assert.equal(row.resources.elapsedSeconds.p50, 12.5);
+  assert.deepEqual(row.resources.gatewayProcessRssPeakBytesSamples, [140_000_000]);
+  assert.equal(row.resources.gatewayProcessRssPeakBytes.p50, 140_000_000);
+  assert.equal(row.resources.gatewayProcessRssPeakDeltaBytes.p50, 40_000_000);
 });
 
 test("prefers Discord summary rttMs over observed-message fallback", async () => {

--- a/scripts/import-discord-rtt.test.mjs
+++ b/scripts/import-discord-rtt.test.mjs
@@ -117,3 +117,55 @@ test("imports Discord resource metrics without changing RTT stats", async () => 
   assert.equal(row.resources.maxRssKb.p50, 204800);
   assert.equal(row.resources.elapsedSeconds.p50, 12.5);
 });
+
+test("prefers Discord summary rttMs over observed-message fallback", async () => {
+  const workspace = await makeWorkspace();
+  const sampleDir = path.join(workspace, "sample-1");
+  await fs.mkdir(sampleDir, { recursive: true });
+  await fs.writeFile(
+    path.join(sampleDir, "discord-qa-summary.json"),
+    `${JSON.stringify({
+      startedAt: "2026-05-16T00:00:00.000Z",
+      finishedAt: "2026-05-16T00:00:45.000Z",
+      counts: { total: 1, passed: 1, failed: 0 },
+      scenarios: [{ id: "discord-canary", status: "pass", rttMs: 6123 }],
+      credentials: { source: "convex", role: "ci" },
+    })}\n`,
+  );
+  await fs.writeFile(
+    path.join(sampleDir, "discord-qa-observed-messages.json"),
+    `${JSON.stringify([
+      {
+        scenarioId: "discord-canary",
+        matchedScenario: true,
+      },
+    ])}\n`,
+  );
+  await fs.writeFile(
+    path.join(workspace, "samples.tsv"),
+    `${path.join(sampleDir, "discord-qa-summary.json")}\t${path.join(
+      sampleDir,
+      "discord-qa-observed-messages.json",
+    )}\n`,
+  );
+
+  await execFileAsync(process.execPath, [
+    IMPORT_SCRIPT,
+    path.join(workspace, "samples.tsv"),
+    "--spec",
+    "openclaw@2026.5.17",
+    "--version",
+    "2026.5.17",
+    "--require-pass",
+  ], { cwd: workspace });
+
+  const result = JSON.parse(
+    await fs.readFile(
+      path.join(workspace, "runs/discord/2026-05-16T000000000Z-openclaw_2026.5.17-discord-rtt/result.json"),
+      "utf8",
+    ),
+  );
+  assert.equal(result.rtt.p50Ms, 6123);
+  assert.deepEqual(result.rtt.sources, ["summary-rtt"]);
+  assert.equal(result.discord.samples[0].rttSource, "summary-rtt");
+});

--- a/scripts/import-live-transport-rtt.mjs
+++ b/scripts/import-live-transport-rtt.mjs
@@ -9,6 +9,7 @@ import {
   channelRttRunsDir,
   resolveChannelRttChannel,
 } from "./channel-rtt-config.mjs";
+import { aggregateResources } from "./resource-metrics.mjs";
 
 function usage() {
   return [
@@ -201,6 +202,25 @@ function readAttemptCount(value) {
   return value;
 }
 
+function extractGatewayResourceMetrics(summary) {
+  const metrics = summary.metrics;
+  if (!metrics || typeof metrics !== "object" || Array.isArray(metrics)) {
+    return {};
+  }
+  return Object.fromEntries(
+    [
+      "gatewayProcessRssStartBytes",
+      "gatewayProcessRssEndBytes",
+      "gatewayProcessRssDeltaBytes",
+      "gatewayProcessRssPeakBytes",
+      "gatewayProcessRssPeakDeltaBytes",
+    ].flatMap((metricName) => {
+      const value = metrics[metricName];
+      return typeof value === "number" && Number.isFinite(value) ? [[metricName, value]] : [];
+    }),
+  );
+}
+
 function selectScenario(summary, scenarioId) {
   const scenario = summary.scenarios.find((item) => item?.id === scenarioId);
   if (!scenario) {
@@ -230,6 +250,7 @@ async function readSample(entry, index, scenarioId) {
       ...(resourceMetrics.elapsed_seconds === undefined
         ? {}
         : { elapsedSeconds: resourceMetrics.elapsed_seconds }),
+      ...extractGatewayResourceMetrics(summary),
     },
     scenario: {
       details: scenario.details,
@@ -282,12 +303,22 @@ async function main() {
   const warmSamples = samples.flatMap((sample) =>
     sample.scenario.status === "pass" ? [sample.scenario.rttMs] : [],
   );
-  const maxRssKbSamples = samples.flatMap((sample) =>
-    typeof sample.resources.maxRssKb === "number" ? [sample.resources.maxRssKb] : [],
-  );
-  const elapsedSecondsSamples = samples.flatMap((sample) =>
-    typeof sample.resources.elapsedSeconds === "number" ? [sample.resources.elapsedSeconds] : [],
-  );
+  const resources =
+    aggregateResources(samples.map((sample) => sample.resources), {
+      kind: "process-max-rss",
+      scope: "qa-command",
+      command: `pnpm openclaw qa ${channel.command}`,
+    }) ?? {
+      measurement: {
+        kind: "process-max-rss",
+        scope: "qa-command",
+        command: `pnpm openclaw qa ${channel.command}`,
+      },
+      maxRssKbSamples: [],
+      elapsedSecondsSamples: [],
+      maxRssKb: numericStats([]),
+      elapsedSeconds: numericStats([]),
+    };
   const attemptSamples = samples.map((sample) => sample.attempts);
   const retryCount = attemptSamples.reduce((total, attempts) => total + Math.max(0, attempts - 1), 0);
   const failedSamples = samples.length - warmSamples.length;
@@ -325,17 +356,7 @@ async function main() {
       failedSamples,
       ...stats(warmSamples),
     },
-    resources: {
-      measurement: {
-        kind: "process-max-rss",
-        scope: "qa-command",
-        command: `pnpm openclaw qa ${channel.command}`,
-      },
-      maxRssKbSamples,
-      elapsedSecondsSamples,
-      maxRssKb: numericStats(maxRssKbSamples),
-      elapsedSeconds: numericStats(elapsedSecondsSamples),
-    },
+    resources,
     samples: samples.map((sample) => ({
       index: sample.index,
       status: sample.scenario.status,

--- a/scripts/import-live-transport-rtt.test.mjs
+++ b/scripts/import-live-transport-rtt.test.mjs
@@ -37,6 +37,13 @@ test("imports live transport summary RTT samples", async () => {
     startedAt: "2026-05-16T00:00:00.000Z",
     finishedAt: "2026-05-16T00:00:02.000Z",
     counts: { total: 1, passed: 1, failed: 0 },
+    metrics: {
+      gatewayProcessRssStartBytes: 100_000_000,
+      gatewayProcessRssEndBytes: 125_000_000,
+      gatewayProcessRssDeltaBytes: 25_000_000,
+      gatewayProcessRssPeakBytes: 140_000_000,
+      gatewayProcessRssPeakDeltaBytes: 40_000_000,
+    },
     scenarios: [
       {
         id: "slack-canary",
@@ -82,6 +89,9 @@ test("imports live transport summary RTT samples", async () => {
   assert.deepEqual(row.resources.maxRssKbSamples, [204800]);
   assert.equal(row.resources.maxRssKb.p50, 204800);
   assert.deepEqual(row.resources.elapsedSecondsSamples, [2.5]);
+  assert.deepEqual(row.resources.gatewayProcessRssPeakBytesSamples, [140_000_000]);
+  assert.equal(row.resources.gatewayProcessRssPeakBytes.p50, 140_000_000);
+  assert.equal(row.resources.gatewayProcessRssPeakDeltaBytes.p50, 40_000_000);
   assert.deepEqual(row.polling.attemptSamples, [2]);
   assert.equal(row.polling.retryCount, 1);
   assert.equal(row.polling.maxAttempts, 2);

--- a/scripts/resource-metrics.mjs
+++ b/scripts/resource-metrics.mjs
@@ -19,6 +19,14 @@ export function numericStats(samples) {
   };
 }
 
+const GATEWAY_RSS_METRIC_NAMES = Object.freeze([
+  "gatewayProcessRssStartBytes",
+  "gatewayProcessRssEndBytes",
+  "gatewayProcessRssDeltaBytes",
+  "gatewayProcessRssPeakBytes",
+  "gatewayProcessRssPeakDeltaBytes",
+]);
+
 function readFiniteNumber(value, label) {
   if (value === undefined || value === "") {
     return undefined;
@@ -56,7 +64,24 @@ export function aggregateResources(samples, measurement) {
   const elapsedSecondsSamples = samples.flatMap((sample) =>
     typeof sample.elapsedSeconds === "number" ? [sample.elapsedSeconds] : [],
   );
-  if (maxRssKbSamples.length === 0 && elapsedSecondsSamples.length === 0) {
+  const gatewayRssStats = Object.fromEntries(
+    GATEWAY_RSS_METRIC_NAMES.flatMap((metricName) => {
+      const metricSamples = samples.flatMap((sample) =>
+        typeof sample[metricName] === "number" ? [sample[metricName]] : [],
+      );
+      return metricSamples.length === 0
+        ? []
+        : [
+            [`${metricName}Samples`, metricSamples],
+            [metricName, numericStats(metricSamples)],
+          ];
+    }),
+  );
+  if (
+    maxRssKbSamples.length === 0 &&
+    elapsedSecondsSamples.length === 0 &&
+    Object.keys(gatewayRssStats).length === 0
+  ) {
     return undefined;
   }
   return {
@@ -65,5 +90,6 @@ export function aggregateResources(samples, measurement) {
     elapsedSecondsSamples,
     maxRssKb: numericStats(maxRssKbSamples),
     elapsedSeconds: numericStats(elapsedSecondsSamples),
+    ...gatewayRssStats,
   };
 }

--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -55,23 +55,23 @@ function assertResources(row, index, label) {
   if (typeof row.resources !== "object" || row.resources === null || Array.isArray(row.resources)) {
     throw new Error(`${label} ${index} has invalid resources`);
   }
-  if (
-    row.resources.maxRssKbSamples !== undefined &&
-    (!Array.isArray(row.resources.maxRssKbSamples) ||
-      row.resources.maxRssKbSamples.some(
-        (sample) => typeof sample !== "number" || !Number.isFinite(sample),
-      ))
-  ) {
-    throw new Error(`${label} ${index} has invalid resources.maxRssKbSamples`);
-  }
-  if (
-    row.resources.elapsedSecondsSamples !== undefined &&
-    (!Array.isArray(row.resources.elapsedSecondsSamples) ||
-      row.resources.elapsedSecondsSamples.some(
-        (sample) => typeof sample !== "number" || !Number.isFinite(sample),
-      ))
-  ) {
-    throw new Error(`${label} ${index} has invalid resources.elapsedSecondsSamples`);
+  for (const samplesName of [
+    "maxRssKbSamples",
+    "elapsedSecondsSamples",
+    "gatewayProcessRssStartBytesSamples",
+    "gatewayProcessRssEndBytesSamples",
+    "gatewayProcessRssDeltaBytesSamples",
+    "gatewayProcessRssPeakBytesSamples",
+    "gatewayProcessRssPeakDeltaBytesSamples",
+  ]) {
+    const samples = row.resources[samplesName];
+    if (
+      samples !== undefined &&
+      (!Array.isArray(samples) ||
+        samples.some((sample) => typeof sample !== "number" || !Number.isFinite(sample)))
+    ) {
+      throw new Error(`${label} ${index} has invalid resources.${samplesName}`);
+    }
   }
   if (row.resources.measurement !== undefined) {
     if (
@@ -91,6 +91,11 @@ function assertResources(row, index, label) {
   for (const [metricName, stats] of Object.entries({
     maxRssKb: row.resources.maxRssKb,
     elapsedSeconds: row.resources.elapsedSeconds,
+    gatewayProcessRssStartBytes: row.resources.gatewayProcessRssStartBytes,
+    gatewayProcessRssEndBytes: row.resources.gatewayProcessRssEndBytes,
+    gatewayProcessRssDeltaBytes: row.resources.gatewayProcessRssDeltaBytes,
+    gatewayProcessRssPeakBytes: row.resources.gatewayProcessRssPeakBytes,
+    gatewayProcessRssPeakDeltaBytes: row.resources.gatewayProcessRssPeakDeltaBytes,
   })) {
     if (stats === undefined) {
       continue;


### PR DESCRIPTION
## Summary

- Imports Discord scenario summary `rttMs` before falling back to observed-message timestamps or full summary duration.
- Imports gateway RSS metrics from OpenClaw QA summaries into resource metric fields.
- Extends importer tests and validator coverage for the new RTT and gateway RSS fields.
- Paired OpenClaw artifact producer PR: https://github.com/openclaw/openclaw/pull/83453

## Root Cause

Newer redacted Discord QA artifacts can omit observed message timestamps. The importer then fell back to whole scenario duration, making redaction shape look like a Discord RTT regression.

## Behavior addressed

Discord RTT rows now use summary-level RTT when available, and resource rows can distinguish gateway-process RSS from command-level RSS.

## Real environment tested

Local `openclaw/openclaw-rtt` checkout on branch `perf/discord-rtt-summary-import`.

## Exact steps or command run after this patch

```sh
npm test -- scripts/import-discord-rtt.test.mjs scripts/import-live-transport-rtt.test.mjs
npm run check
```

## Evidence after fix

- Importer tests passed: 19 tests.
- Repository validation passed: `ok: 105 RTT rows`, `26 Discord RTT rows`, `28 Channel RTT rows`.

## Observed result after fix

Discord importer prefers the corrected `summary-rtt` source, and live transport imports include gateway RSS start/end/delta/peak resource fields.

## What was not tested

No dashboard UI presentation changes were included.

## Risks

- Risk: old artifacts without summary RTT still use fallback logic.
  Mitigation: fallback order is preserved after the new summary RTT path.
