### PR TITLE
fix(ci): right-size RTT runners

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,5 +1,6 @@
 self-hosted-runner:
   labels:
+    - blacksmith-16vcpu-ubuntu-2404
     - blacksmith-32vcpu-ubuntu-2404
     - crabbox
     - openclaw

--- a/.github/workflows/main-channel-rtt.yml
+++ b/.github/workflows/main-channel-rtt.yml
@@ -99,15 +99,15 @@ jobs:
     name: Measure OpenClaw main ${{ matrix.label }} RTT
     needs: resolve
     if: needs.resolve.outputs.should_run == 'true'
-    runs-on: blacksmith-32vcpu-ubuntu-2404
+    runs-on: blacksmith-16vcpu-ubuntu-2404
     timeout-minutes: 120
     environment: qa-live-shared
     concurrency:
       group: channel-rtt-measure-${{ matrix.channel }}-${{ github.ref }}
-      cancel-in-progress: false
+      cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     strategy:
       fail-fast: false
-      max-parallel: 2
+      max-parallel: 1
       matrix: ${{ fromJSON(needs.resolve.outputs.matrix) }}
     steps:
       - name: Checkout RTT tracker

--- a/.github/workflows/main-rtt.yml
+++ b/.github/workflows/main-rtt.yml
@@ -26,7 +26,7 @@ env:
 jobs:
   measure:
     name: Measure OpenClaw main RTT
-    runs-on: blacksmith-32vcpu-ubuntu-2404
+    runs-on: blacksmith-16vcpu-ubuntu-2404
     timeout-minutes: 90
     steps:
       - name: Checkout RTT tracker

--- a/.github/workflows/main-surface-rtt.yml
+++ b/.github/workflows/main-surface-rtt.yml
@@ -36,11 +36,11 @@ env:
 jobs:
   measure-surface-rtt:
     name: Measure OpenClaw main surface RTT
-    runs-on: blacksmith-32vcpu-ubuntu-2404
+    runs-on: blacksmith-16vcpu-ubuntu-2404
     timeout-minutes: 45
     concurrency:
       group: surface-rtt-measure-main-${{ github.ref }}
-      cancel-in-progress: false
+      cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     steps:
       - name: Checkout RTT tracker
         uses: actions/checkout@v6

--- a/.github/workflows/release-channel-rtt.yml
+++ b/.github/workflows/release-channel-rtt.yml
@@ -83,7 +83,7 @@ jobs:
     name: Measure OpenClaw ${{ matrix.package.label }} release RTT
     needs: resolve
     if: needs.resolve.outputs.should_run == 'true'
-    runs-on: blacksmith-32vcpu-ubuntu-2404
+    runs-on: blacksmith-16vcpu-ubuntu-2404
     timeout-minutes: 120
     environment: qa-live-shared
     concurrency:

--- a/.github/workflows/release-surface-rtt.yml
+++ b/.github/workflows/release-surface-rtt.yml
@@ -76,7 +76,7 @@ jobs:
     name: Measure OpenClaw ${{ matrix.package.label }} release RTT
     needs: resolve
     if: needs.resolve.outputs.should_run == 'true'
-    runs-on: blacksmith-32vcpu-ubuntu-2404
+    runs-on: blacksmith-16vcpu-ubuntu-2404
     timeout-minutes: 60
     concurrency:
       group: surface-rtt-measure-${{ matrix.package.surface }}-${{ github.ref }}

--- a/.github/workflows/stable-release-discord-rtt.yml
+++ b/.github/workflows/stable-release-discord-rtt.yml
@@ -41,7 +41,7 @@ env:
 jobs:
   resolve:
     name: Resolve OpenClaw Discord release packages
-    runs-on: blacksmith-32vcpu-ubuntu-2404
+    runs-on: blacksmith-16vcpu-ubuntu-2404
     outputs:
       anchor: ${{ steps.release.outputs.anchor }}
       matrix: ${{ steps.release.outputs.matrix }}
@@ -87,7 +87,7 @@ jobs:
       cancel-in-progress: false
     strategy:
       fail-fast: false
-      max-parallel: 8
+      max-parallel: 2
       matrix:
         package: ${{ fromJSON(needs.resolve.outputs.matrix) }}
     steps:

--- a/.github/workflows/stable-release-rtt.yml
+++ b/.github/workflows/stable-release-rtt.yml
@@ -44,7 +44,7 @@ env:
 jobs:
   measure:
     name: Measure OpenClaw release RTT
-    runs-on: blacksmith-32vcpu-ubuntu-2404
+    runs-on: blacksmith-16vcpu-ubuntu-2404
     timeout-minutes: 90
     steps:
       - name: Checkout RTT tracker


### PR DESCRIPTION
## Summary
- move RTT measurement jobs from Blacksmith 32-vCPU to 16-vCPU runners
- serialize bursty channel/surface matrices and cancel superseded pull-request measurements
- reduce stable Discord RTT matrix parallelism
- register the 16-vCPU label with actionlint

## Verification
- `npm run check`
- Ruby YAML parse for changed workflows and actionlint config
- `git diff --check`
- branch autoreview clean

Release and main measurement jobs keep their existing concurrency groups; this only reduces runner size and superseded-PR fan-out.