### PR TITLE
fix(rtt): restore current OpenClaw artifacts

### DIFF
--- a/.github/workflows/main-discord-rtt.yml
+++ b/.github/workflows/main-discord-rtt.yml
@@ -157,18 +157,25 @@ jobs:
                 echo "attempts=${attempt}"
                 echo "exit_status=${status}"
               } >>"$metrics_path"
-              if [[ -f "$summary_path" && -f "$observed_path" ]]; then
+              if [[ -f "$summary_path" ]]; then
                 break
               fi
               if [[ "$attempt" -lt 3 ]]; then
                 sleep $((attempt * 15))
               fi
             done
-            if [[ ! -f "$summary_path" || ! -f "$observed_path" ]]; then
-              echo "No Discord QA artifacts produced for sample ${sample}." >&2
+            if [[ ! -f "$summary_path" ]]; then
+              echo "No Discord QA evidence produced for sample ${sample}." >&2
+              if [[ "$status" -eq 0 ]]; then
+                status=1
+              fi
               exit "$status"
             fi
-            printf '%s\t%s\t%s\n' "${PWD}/${summary_path}" "${PWD}/${observed_path}" "${PWD}/${metrics_path}" >>"$sample_paths"
+            observed_value=""
+            if [[ -f "$observed_path" ]]; then
+              observed_value="${PWD}/${observed_path}"
+            fi
+            printf '%s\t%s\t%s\n' "${PWD}/${summary_path}" "$observed_value" "${PWD}/${metrics_path}" >>"$sample_paths"
           done
 
       - name: Import Discord RTT result

--- a/.github/workflows/main-rtt.yml
+++ b/.github/workflows/main-rtt.yml
@@ -54,6 +54,10 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
 
+      - name: Preserve Telegram harness stdin
+        working-directory: openclaw-rtt
+        run: node scripts/patch-openclaw-telegram-harness.mjs ../openclaw
+
       - name: Setup pnpm
         shell: bash
         run: |
@@ -146,6 +150,9 @@ jobs:
           evidence_path="$output/raw/qa-evidence.json"
           if [[ ! -f "$evidence_path" ]]; then
             echo "No qa-evidence.json produced." >&2
+            if [[ "$status" -eq 0 ]]; then
+              status=1
+            fi
             exit "$status"
           fi
           {

--- a/.github/workflows/stable-release-discord-rtt.yml
+++ b/.github/workflows/stable-release-discord-rtt.yml
@@ -253,18 +253,25 @@ jobs:
                 echo "attempts=${attempt}"
                 echo "exit_status=${status}"
               } >>"$metrics_path"
-              if [[ -f "$summary_path" && -f "$observed_path" ]]; then
+              if [[ -f "$summary_path" ]]; then
                 break
               fi
               if [[ "$attempt" -lt 3 ]]; then
                 sleep $((attempt * 15))
               fi
             done
-            if [[ ! -f "$summary_path" || ! -f "$observed_path" ]]; then
-              echo "No Discord QA artifacts produced for sample ${sample}." >&2
+            if [[ ! -f "$summary_path" ]]; then
+              echo "No Discord QA evidence produced for sample ${sample}." >&2
+              if [[ "$status" -eq 0 ]]; then
+                status=1
+              fi
               exit "$status"
             fi
-            printf '%s\t%s\t%s\n' "${PWD}/${summary_path}" "${PWD}/${observed_path}" "${PWD}/${metrics_path}" >>"$sample_paths"
+            observed_value=""
+            if [[ -f "$observed_path" ]]; then
+              observed_value="${PWD}/${observed_path}"
+            fi
+            printf '%s\t%s\t%s\n' "${PWD}/${summary_path}" "$observed_value" "${PWD}/${metrics_path}" >>"$sample_paths"
           done
 
       - name: Prepare Discord release import artifact
@@ -356,11 +363,15 @@ jobs:
               summary_path="${sample_dir}/qa-evidence.json"
               observed_path="${sample_dir}/discord-qa-observed-messages.json"
               metrics_path="${sample_dir}/resource-metrics.env"
-              if [[ ! -f "$summary_path" || ! -f "$observed_path" || ! -f "$metrics_path" ]]; then
+              if [[ ! -f "$summary_path" || ! -f "$metrics_path" ]]; then
                 echo "Missing Discord release artifacts under ${sample_dir}." >&2
                 exit 1
               fi
-              printf '%s\t%s\t%s\n' "$summary_path" "$observed_path" "$metrics_path" >>"$sample_paths"
+              observed_value=""
+              if [[ -f "$observed_path" ]]; then
+                observed_value="$observed_path"
+              fi
+              printf '%s\t%s\t%s\n' "$summary_path" "$observed_value" "$metrics_path" >>"$sample_paths"
             done < <(find "${import_dir}/artifacts" -mindepth 1 -maxdepth 1 -type d -name 'sample-*' | sort -V)
             if [[ "${{ needs.resolve.outputs.rss_backfill }}" == "true" ]]; then
               node scripts/backfill-release-rss.mjs \

--- a/.github/workflows/stable-release-rtt.yml
+++ b/.github/workflows/stable-release-rtt.yml
@@ -81,6 +81,11 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
 
+      - name: Preserve Telegram harness stdin
+        if: steps.release.outputs.should_run == 'true'
+        working-directory: openclaw-rtt
+        run: node scripts/patch-openclaw-telegram-harness.mjs ../openclaw
+
       - name: Set up Blacksmith Docker Builder
         if: steps.release.outputs.should_run == 'true'
         uses: useblacksmith/setup-docker-builder@ab5c1da94f53f5cd75c1038092aa276dddfccbba # v1

--- a/scripts/import-discord-rtt.mjs
+++ b/scripts/import-discord-rtt.mjs
@@ -166,8 +166,8 @@ async function readSampleEntries(samplesPath) {
     .filter(Boolean)
     .map((line, index) => {
       const [summaryPath, observedMessagesPath, resourceMetricsPath] = line.split("\t");
-      if (!summaryPath || !observedMessagesPath) {
-        throw new Error(`Invalid sample-paths line ${index + 1}: expected summary and observed paths.`);
+      if (!summaryPath) {
+        throw new Error(`Invalid sample-paths line ${index + 1}: expected a summary path.`);
       }
       return { summaryPath, observedMessagesPath, resourceMetricsPath };
     });
@@ -265,7 +265,9 @@ function extractGatewayResourceMetrics(summary) {
 
 async function readSample(entry, index) {
   const summary = validateSummary(normalizeEvidenceSummary(await readJson(path.resolve(entry.summaryPath))));
-  const observedMessages = await readJson(path.resolve(entry.observedMessagesPath));
+  const observedMessages = entry.observedMessagesPath
+    ? await readJson(path.resolve(entry.observedMessagesPath))
+    : [];
   const resources = entry.resourceMetricsPath
     ? await readResourceMetrics(path.resolve(entry.resourceMetricsPath))
     : undefined;

--- a/scripts/import-discord-rtt.test.mjs
+++ b/scripts/import-discord-rtt.test.mjs
@@ -103,6 +103,52 @@ test("imports Discord qa-evidence summaries", async () => {
   assert.equal(row.mode.providerMode, "mock-openai");
 });
 
+test("imports Discord qa-evidence without the retired observed-message sidecar", async () => {
+  const workspace = await makeWorkspace();
+  const sampleDir = path.join(workspace, "sample-1");
+  await fs.mkdir(sampleDir, { recursive: true });
+  await fs.writeFile(
+    path.join(sampleDir, "qa-evidence.json"),
+    `${JSON.stringify({
+      kind: "openclaw.qa.evidence-summary",
+      schemaVersion: 2,
+      generatedAt: "2026-07-18T03:59:09.424Z",
+      entries: [
+        {
+          test: { id: "discord-canary", title: "Discord canary echo" },
+          execution: { provider: { fixture: "mock-openai" } },
+          result: { status: "pass", timing: { rttMs: 2140 } },
+        },
+      ],
+    })}\n`,
+  );
+  await fs.writeFile(
+    path.join(workspace, "samples.tsv"),
+    `${path.join(sampleDir, "qa-evidence.json")}\t\t\n`,
+  );
+
+  await execFileAsync(process.execPath, [
+    IMPORT_SCRIPT,
+    path.join(workspace, "samples.tsv"),
+    "--spec",
+    "openclaw@main",
+    "--version",
+    "2026.7.2+3659c85e53",
+    "--require-pass",
+  ], { cwd: workspace });
+
+  const [row] = (await fs.readFile(
+    path.join(workspace, "data/channels/discord/2026.7.2+3659c85e53.jsonl"),
+    "utf8",
+  ))
+    .trim()
+    .split("\n")
+    .map((line) => JSON.parse(line));
+  assert.equal(row.run.status, "pass");
+  assert.equal(row.rtt.p50Ms, 2140);
+  assert.deepEqual(row.rtt.sources, ["summary-rtt"]);
+});
+
 test("imports failed Discord qa-evidence summaries without timing", async () => {
   const workspace = await makeWorkspace();
   const sampleDir = path.join(workspace, "sample-1");

--- a/scripts/patch-openclaw-telegram-harness.mjs
+++ b/scripts/patch-openclaw-telegram-harness.mjs
@@ -1,0 +1,70 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+const callSites = [
+  {
+    label: "npm-telegram-package-install",
+    broken:
+      'run_logged_print_heartbeat "npm-telegram-package-install" 60 docker_e2e_docker_run_cmd run --rm \\',
+    fixed: 'run_logged_print "npm-telegram-package-install" docker_e2e_docker_run_cmd run --rm \\',
+  },
+  {
+    label: "npm-telegram-live-suite",
+    broken:
+      'run_logged_print_heartbeat "npm-telegram-live-suite" 60 docker_e2e_run_with_harness \\',
+    fixed: 'run_logged_print "npm-telegram-live-suite" docker_e2e_run_with_harness \\',
+  },
+];
+
+function usage() {
+  return "Usage: node scripts/patch-openclaw-telegram-harness.mjs <openclaw-repo-root>";
+}
+
+async function main() {
+  const [repoRoot, ...extraArgs] = process.argv.slice(2);
+  if (!repoRoot || extraArgs.length > 0) {
+    throw new Error(usage());
+  }
+
+  const scriptPath = path.resolve(repoRoot, "scripts/e2e/npm-telegram-live-docker.sh");
+  const original = await fs.readFile(scriptPath, "utf8");
+  const lines = original.split("\n");
+  const states = callSites.map((callSite) => {
+    const matches = lines
+      .map((line, index) => ({ index, line }))
+      .filter(({ line }) => line.includes(`"${callSite.label}"`));
+    if (matches.length !== 1) {
+      return { kind: "unknown" };
+    }
+    const [match] = matches;
+    if (match.line === callSite.broken) {
+      return { index: match.index, kind: "broken" };
+    }
+    if (match.line === callSite.fixed) {
+      return { index: match.index, kind: "fixed" };
+    }
+    return { kind: "unknown" };
+  });
+  const isBrokenContract = states.every((state) => state.kind === "broken");
+  const isFixedContract = states.every((state) => state.kind === "fixed");
+  if (!isBrokenContract && !isFixedContract) {
+    throw new Error(`Unsupported Telegram harness logging contract in ${scriptPath}`);
+  }
+
+  if (isBrokenContract) {
+    for (let index = 0; index < callSites.length; index += 1) {
+      lines[states[index].index] = callSites[index].fixed;
+    }
+    await fs.writeFile(scriptPath, lines.join("\n"));
+  }
+  process.stdout.write(
+    isBrokenContract
+      ? `patched ${callSites.length} Telegram harness stdin consumers\n`
+      : "Telegram harness stdin consumers already preserve input\n",
+  );
+}
+
+main().catch((error) => {
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+  process.exitCode = 1;
+});

--- a/scripts/patch-openclaw-telegram-harness.test.mjs
+++ b/scripts/patch-openclaw-telegram-harness.test.mjs
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import test from "node:test";
+
+const execFileAsync = promisify(execFile);
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const PATCH_SCRIPT = path.join(REPO_ROOT, "scripts/patch-openclaw-telegram-harness.mjs");
+
+async function makeFixture(contents) {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-telegram-harness-test-"));
+  const scriptPath = path.join(root, "scripts/e2e/npm-telegram-live-docker.sh");
+  await fs.mkdir(path.dirname(scriptPath), { recursive: true });
+  await fs.writeFile(scriptPath, contents);
+  return { root, scriptPath };
+}
+
+test("preserves heredoc stdin across the Telegram heartbeat wrapper regression", async (t) => {
+  const { root, scriptPath } = await makeFixture(`#!/usr/bin/env bash
+run_logged_print_heartbeat "npm-telegram-package-install" 60 docker_e2e_docker_run_cmd run --rm \\
+run_logged_print_heartbeat "npm-telegram-live-suite" 60 docker_e2e_run_with_harness \\
+`);
+  t.after(() => fs.rm(root, { force: true, recursive: true }));
+
+  const first = await execFileAsync(process.execPath, [PATCH_SCRIPT, root]);
+  assert.match(first.stdout, /patched 2 Telegram harness stdin consumers/u);
+  const patched = await fs.readFile(scriptPath, "utf8");
+  assert.match(
+    patched,
+    /run_logged_print "npm-telegram-package-install" docker_e2e_docker_run_cmd run --rm/u,
+  );
+  assert.match(
+    patched,
+    /run_logged_print "npm-telegram-live-suite" docker_e2e_run_with_harness/u,
+  );
+  assert.doesNotMatch(patched, /run_logged_print_heartbeat/u);
+
+  const second = await execFileAsync(process.execPath, [PATCH_SCRIPT, root]);
+  assert.match(second.stdout, /already preserve input/u);
+  assert.equal(await fs.readFile(scriptPath, "utf8"), patched);
+});
+
+test("fails closed for an unknown upstream Telegram harness contract", async (t) => {
+  const { root } = await makeFixture("#!/usr/bin/env bash\necho unknown\n");
+  t.after(() => fs.rm(root, { force: true, recursive: true }));
+
+  await assert.rejects(
+    execFileAsync(process.execPath, [PATCH_SCRIPT, root]),
+    /Unsupported Telegram harness logging contract/u,
+  );
+});
+
+test("fails closed for mixed or duplicate Telegram harness contracts", async (t) => {
+  const fixtures = [
+    `run_logged_print_heartbeat "npm-telegram-package-install" 60 docker_e2e_docker_run_cmd run --rm
+run_logged_print "npm-telegram-live-suite" docker_e2e_run_with_harness
+`,
+    `run_logged_print_heartbeat "npm-telegram-package-install" 60 docker_e2e_docker_run_cmd run --rm
+run_logged_print_heartbeat "npm-telegram-package-install" 60 docker_e2e_docker_run_cmd run --rm
+run_logged_print_heartbeat "npm-telegram-live-suite" 60 docker_e2e_run_with_harness
+`,
+    `# run_logged_print_heartbeat "npm-telegram-package-install" 60 docker_e2e_docker_run_cmd run --rm \\
+custom_logger "npm-telegram-package-install" docker_e2e_docker_run_cmd run --rm \\
+run_logged_print_heartbeat "npm-telegram-live-suite" 60 docker_e2e_run_with_harness \\
+`,
+  ];
+  const roots = [];
+  t.after(() => Promise.all(roots.map((root) => fs.rm(root, { force: true, recursive: true }))));
+
+  for (const fixture of fixtures) {
+    const { root } = await makeFixture(fixture);
+    roots.push(root);
+    await assert.rejects(
+      execFileAsync(process.execPath, [PATCH_SCRIPT, root]),
+      /Unsupported Telegram harness logging contract/u,
+    );
+  }
+});


### PR DESCRIPTION
## Summary

- preserve stdin for the current OpenClaw Telegram Docker harness after upstream heartbeat logging began backgrounding heredoc consumers
- fail closed when Telegram or Discord QA exits successfully without producing required evidence
- accept current Discord qa-evidence without the retired observed-message sidecar

## Live root causes

The Node 26 workflow fix crossed the original engine gate and exposed two newer OpenClaw main contract changes:

- OpenClaw commit e7801deb57d9 changed the Telegram Docker heredoc consumers to a background heartbeat wrapper, so both bash scripts received empty stdin and exited successfully without qa-evidence
- current Discord QA writes qa-evidence.json but no longer writes discord-qa-observed-messages.json; the RTT workflow retried passing scenarios and then imported an empty sample list

The Telegram compatibility patch accepts exactly the known two-call broken layout or the fully fixed upstream layout. Any mixed, duplicate, commented, whitespace-drifted, or unknown layout fails before mutation.

## Proof

- actionlint with the repository config
- npm test: 46 passing
- npm run check: data validation and README generation clean
- git diff --check
- Codex autoreview: two accepted fail-closed findings fixed; final review clean with no accepted or actionable findings
- live evidence: Main Surface, Release Surface, Main Channel, and Release Channel passed on Node 26; failed Telegram and Discord runs precisely reproduced the artifact contracts fixed here
