### PR TITLE
fix: align Telegram RTT scenario

### DIFF
--- a/.github/workflows/main-rtt.yml
+++ b/.github/workflows/main-rtt.yml
@@ -131,7 +131,7 @@ jobs:
             OPENCLAW_NPM_TELEGRAM_PACKAGE_TGZ="${{ steps.pack.outputs.package_tgz }}"
             OPENCLAW_NPM_TELEGRAM_OUTPUT_DIR="$output/raw"
             OPENCLAW_NPM_TELEGRAM_PROVIDER_MODE=mock-openai
-            OPENCLAW_NPM_TELEGRAM_SCENARIOS=telegram-mentioned-message-reply
+            OPENCLAW_NPM_TELEGRAM_SCENARIOS=channel-canary
             OPENCLAW_NPM_TELEGRAM_RTT_SAMPLES="$samples"
             OPENCLAW_QA_TELEGRAM_SCENARIO_TIMEOUT_MS=240000
           )

--- a/.github/workflows/stable-release-rtt.yml
+++ b/.github/workflows/stable-release-rtt.yml
@@ -148,7 +148,7 @@ jobs:
             OPENCLAW_NPM_TELEGRAM_PACKAGE_SPEC="$spec" \
             OPENCLAW_NPM_TELEGRAM_OUTPUT_DIR="$output/raw" \
             OPENCLAW_NPM_TELEGRAM_PROVIDER_MODE=mock-openai \
-            OPENCLAW_NPM_TELEGRAM_SCENARIOS=telegram-mentioned-message-reply \
+            OPENCLAW_NPM_TELEGRAM_SCENARIOS=channel-canary \
             OPENCLAW_NPM_TELEGRAM_RTT_SAMPLES=20 \
             OPENCLAW_QA_TELEGRAM_SCENARIO_TIMEOUT_MS=240000 \
               /usr/bin/time \
@@ -219,7 +219,7 @@ jobs:
             OPENCLAW_NPM_TELEGRAM_PACKAGE_SPEC="$spec" \
             OPENCLAW_NPM_TELEGRAM_OUTPUT_DIR="$output/raw" \
             OPENCLAW_NPM_TELEGRAM_PROVIDER_MODE=mock-openai \
-            OPENCLAW_NPM_TELEGRAM_SCENARIOS=telegram-mentioned-message-reply \
+            OPENCLAW_NPM_TELEGRAM_SCENARIOS=channel-canary \
             OPENCLAW_NPM_TELEGRAM_RTT_SAMPLES=20 \
             OPENCLAW_QA_TELEGRAM_SCENARIO_TIMEOUT_MS=240000 \
               /usr/bin/time \

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ channel test driver -> OpenClaw channel transport -> gateway/agent turn -> outbo
 
 That path can include channel API latency, polling/webhook timing, gateway routing, provider turn time, outbound send, and driver observation delay. `p50` is the median successful sample; `p95` is the tail sample. RSS appears when the importing workflow collected process resource metrics around the sampled command; older release rows stay blank until an RSS backfill run updates only the resource fields.
 
-Treat cross-channel numbers as coverage and regression signal, not a pure transport ranking. Telegram release rows use `telegram-mentioned-message-reply`; Discord release rows use `discord-canary`; Slack and WhatsApp use `openclaw qa <channel>` canaries. RSS is not pure channel transport memory: for Discord, Slack, and WhatsApp it includes the QA-lab command process and any cold-start overhead. `-` cells mean no successful RTT sample was imported for that channel/version yet, or an imported all-failed run exists but produced no usable RTT value.
+Treat cross-channel numbers as coverage and regression signal, not a pure transport ranking. Telegram release rows use `channel-canary`; Discord release rows use `discord-canary`; Slack and WhatsApp use `openclaw qa <channel>` canaries. RSS is not pure channel transport memory: for Discord, Slack, and WhatsApp it includes the QA-lab command process and any cold-start overhead. `-` cells mean no successful RTT sample was imported for that channel/version yet, or an imported all-failed run exists but produced no usable RTT value.
 
 Reports:
 
@@ -251,7 +251,7 @@ Latest imported surface run: `2026-07-18T03:57:29.998Z`
 
 ## Telegram Release Runs
 
-Telegram release runs use the OpenClaw package Telegram live QA lane on Blacksmith with `mock-openai`, scenario `telegram-mentioned-message-reply`, 20 target RTT checks, a 240s scenario timeout, and a 30s per-check timeout. New rows import aggregate timing from `qa-evidence.json`; older rows imported by the retired package RTT wrapper keep their historical per-sample arrays.
+Telegram release runs use the OpenClaw package Telegram live QA lane on Blacksmith with `mock-openai`, scenario `channel-canary`, 20 target RTT checks, a 240s scenario timeout, and a 30s per-check timeout. New rows import aggregate timing from `qa-evidence.json`; older rows imported by the retired package RTT wrapper keep their historical per-sample arrays.
 
 The system under test is the published package running its own Telegram bot. The OpenClaw repo only supplies the mock model server and Telegram driver. `p50` is the median normal-reply RTT. Log notes: [2026-05-02 Testbox stable sweep](logs/2026-05-02-testbox-stable-sweep.md).
 

--- a/scripts/backfill-release-rss.test.mjs
+++ b/scripts/backfill-release-rss.test.mjs
@@ -27,7 +27,7 @@ test("backfills Telegram RSS without touching RTT p50/p95", async () => {
       durationMs: 60000,
       status: "pass",
     },
-    mode: { providerMode: "mock-openai", scenarios: ["telegram-mentioned-message-reply"] },
+    mode: { providerMode: "mock-openai", scenarios: ["channel-canary"] },
     rtt: { warmSamples: [1000, 2000], failedSamples: 0, p50Ms: 1000, p95Ms: 2000 },
   };
   await fs.mkdir(path.join(workspace, "data/channels/telegram"), { recursive: true });

--- a/scripts/channel-rtt-config.mjs
+++ b/scripts/channel-rtt-config.mjs
@@ -21,7 +21,7 @@ export const CHANNEL_RTT_CHANNELS = {
   },
   telegram: {
     command: "telegram",
-    defaultScenario: "telegram-mentioned-message-reply",
+    defaultScenario: "channel-canary",
     label: "Telegram",
     releaseSkipVersions: {
       "2026.7.1-beta.4":

--- a/scripts/import-result.mjs
+++ b/scripts/import-result.mjs
@@ -11,7 +11,7 @@ import { aggregateResources, readResourceMetrics } from "./resource-metrics.mjs"
 const TELEGRAM_CHANNEL = {
   id: "telegram",
   label: "Telegram",
-  scenario: "telegram-mentioned-message-reply",
+  scenario: "channel-canary",
 };
 
 function usage() {

--- a/scripts/import-result.test.mjs
+++ b/scripts/import-result.test.mjs
@@ -64,7 +64,7 @@ test("imports Telegram qa-evidence as the existing RTT row shape", async () => {
       {
         test: {
           kind: "live-transport-check",
-          id: "telegram-mentioned-message-reply",
+          id: "channel-canary",
           title: "Telegram mentioned message gets a reply",
         },
         execution: {
@@ -118,7 +118,7 @@ test("imports Telegram qa-evidence as the existing RTT row shape", async () => {
   assert.deepEqual(row.channel, {
     id: "telegram",
     label: "Telegram",
-    scenario: "telegram-mentioned-message-reply",
+    scenario: "channel-canary",
   });
   assert.equal(row.package.spec, "openclaw@main");
   assert.equal(row.package.version, "2026.6.2+abcdef1234");
@@ -173,7 +173,7 @@ test("rejects qa-evidence without aggregate Telegram RTT samples", async () => {
       {
         test: {
           kind: "live-transport-check",
-          id: "telegram-mentioned-message-reply",
+          id: "channel-canary",
           title: "Telegram mentioned message gets a reply",
         },
         execution: {
@@ -207,6 +207,6 @@ test("rejects qa-evidence without aggregate Telegram RTT samples", async () => {
       ],
       { cwd: workspace },
     ),
-    /telegram-mentioned-message-reply must include positive result\.timing\.samples/u,
+    /channel-canary must include positive result\.timing\.samples/u,
   );
 });

--- a/scripts/resolve-openclaw-package.test.mjs
+++ b/scripts/resolve-openclaw-package.test.mjs
@@ -30,7 +30,7 @@ function releaseRow(version, status = "pass") {
       durationMs: 2000,
       status,
     },
-    mode: { providerMode: "mock-openai", scenarios: ["telegram-mentioned-message-reply"] },
+    mode: { providerMode: "mock-openai", scenarios: ["channel-canary"] },
     rtt: { warmSamples: [1000, 2000], p50Ms: 1000, p95Ms: 2000 },
   };
 }

--- a/scripts/update-readme.mjs
+++ b/scripts/update-readme.mjs
@@ -298,7 +298,7 @@ function mainSurfaceDashboardRows(rows) {
 
 function mainDashboardRows(telegramRows, discordRows, channelRows) {
   return [
-    mainDashboardEntry("Telegram", "telegram-mentioned-message-reply", telegramRows),
+    mainDashboardEntry("Telegram", "channel-canary", telegramRows),
     mainDashboardEntry("Discord", "discord-canary", discordRows),
     ...mainChannelDashboardRows(channelRows),
   ].sort((left, right) => {


### PR DESCRIPTION
## Summary

- switch Telegram package RTT workflows to OpenClaw's current `channel-canary` scenario
- align import metadata, dashboard selection, tests, and documentation
- preserve historical stored rows unchanged

## Proof

- `actionlint`
- `npm test` (46 tests)
- `npm run check`
- `git diff --check`
- autoreview clean after checking the authoritative current OpenClaw scenario catalog and RTT runner

Live failure proof: current OpenClaw rejects retired `telegram-mentioned-message-reply`; current source defines `channel-canary` and uses it as the default RTT check.
