### PR TITLE
fix: import current Telegram evidence

### DIFF
--- a/scripts/import-result.mjs
+++ b/scripts/import-result.mjs
@@ -166,12 +166,10 @@ function buildResultFromEvidence(evidence, args) {
     throw new Error("input must be an OpenClaw qa-evidence.json summary.");
   }
   const { finishedAtMs, startedAtMs } = requireEvidenceArgs(args);
-  const canary = evidenceEntry(evidence, "telegram-canary");
   const mention = evidenceEntry(evidence, TELEGRAM_CHANNEL.scenario);
   const packageSpec = packageSpecFromEvidence(mention);
-  const canaryTiming = readTiming(canary, "telegram-canary");
   const mentionTiming = readTiming(mention, TELEGRAM_CHANNEL.scenario);
-  const canaryMs = finiteTimingNumber(canaryTiming, "rttMs");
+  const canaryMs = finiteTimingNumber(mentionTiming, "rttMs");
   const sampleCount = requirePositiveTimingNumber(
     mentionTiming,
     "samples",
@@ -190,7 +188,7 @@ function buildResultFromEvidence(evidence, args) {
       finishedAt: args.finishedAt,
       durationMs: finishedAtMs - startedAtMs,
       status:
-        statusFromEvidence([canary, mention]) === "pass" &&
+        statusFromEvidence([mention]) === "pass" &&
         typeof canaryMs === "number" &&
         typeof mentionReplyMs === "number"
           ? "pass"

--- a/scripts/import-result.test.mjs
+++ b/scripts/import-result.test.mjs
@@ -40,30 +40,6 @@ test("imports Telegram qa-evidence as the existing RTT row shape", async () => {
       {
         test: {
           kind: "live-transport-check",
-          id: "telegram-canary",
-          title: "Telegram canary",
-        },
-        execution: {
-          packageSource: {
-            kind: "npm-package",
-            spec: "openclaw@main",
-          },
-          provider: {
-            id: "openai",
-            live: false,
-            fixture: "mock-openai",
-          },
-        },
-        result: {
-          status: "pass",
-          timing: {
-            rttMs: 900,
-          },
-        },
-      },
-      {
-        test: {
-          kind: "live-transport-check",
           id: "channel-canary",
           title: "Telegram mentioned message gets a reply",
         },
@@ -126,7 +102,7 @@ test("imports Telegram qa-evidence as the existing RTT row shape", async () => {
   assert.equal(row.run.durationMs, 30_000);
   assert.equal(row.mode.providerMode, "mock-openai");
   assert.equal(row.mode.source, "qa-evidence");
-  assert.equal(row.rtt.canaryMs, 900);
+  assert.equal(row.rtt.canaryMs, 1200);
   assert.equal(row.rtt.mentionReplyMs, 1200);
   assert.equal(row.rtt.avgMs, 1300);
   assert.equal(row.rtt.p50Ms, 1200);
@@ -157,19 +133,6 @@ test("rejects qa-evidence without aggregate Telegram RTT samples", async () => {
     schemaVersion: 2,
     generatedAt: "2026-06-12T20:00:20.000Z",
     entries: [
-      {
-        test: {
-          kind: "live-transport-check",
-          id: "telegram-canary",
-          title: "Telegram canary",
-        },
-        result: {
-          status: "pass",
-          timing: {
-            rttMs: 900,
-          },
-        },
-      },
       {
         test: {
           kind: "live-transport-check",


### PR DESCRIPTION
## Summary

- import Telegram RTT timing from the current single `channel-canary` evidence entry
- remove the retired `telegram-canary` evidence dependency
- preserve the existing tracker row shape

## Proof

- `npm test` (46 tests)
- `npm run check`
- `git diff --check`
- autoreview clean

Default-branch runs `29631372270` and `29631373098` both passed the live RTT step, then failed import because current evidence contained only `channel-canary`.
