### PR TITLE
fix(ci): measure main surface from built OpenClaw

### DIFF
--- a/.github/workflows/main-surface-rtt.yml
+++ b/.github/workflows/main-surface-rtt.yml
@@ -9,6 +9,7 @@ on:
       - "scripts/import-surface-rtt.mjs"
       - "scripts/measure-control-ui-rtt.mjs"
       - "scripts/measure-rpc-rtt.mjs"
+      - "scripts/measure-rpc-rtt.test.mjs"
       - "scripts/read-surface-rtt-rows.mjs"
       - "scripts/surface-rtt-config.mjs"
       - "scripts/surface-rtt-summary.mjs"
@@ -98,6 +99,13 @@ jobs:
         run: |
           set -euo pipefail
           node scripts/ensure-playwright-chromium.mjs
+
+      - name: Build OpenClaw
+        working-directory: openclaw
+        shell: bash
+        run: |
+          set -euo pipefail
+          pnpm build
 
       - name: Resolve OpenClaw ref
         id: openclaw_ref

--- a/scripts/measure-rpc-rtt.mjs
+++ b/scripts/measure-rpc-rtt.mjs
@@ -1,10 +1,15 @@
 import { randomUUID } from "node:crypto";
+import { once } from "node:events";
 import fs from "node:fs/promises";
 import net from "node:net";
 import path from "node:path";
 import { spawn } from "node:child_process";
 import { performance } from "node:perf_hooks";
+import { setTimeout as wait } from "node:timers/promises";
 import { pathToFileURL } from "node:url";
+
+const REQUEST_TIMEOUT_MS = 10_000;
+const WARMUP_TIMEOUT_MS = 30_000;
 
 function usage() {
   return [
@@ -87,10 +92,6 @@ function stats(samples) {
   };
 }
 
-function wait(ms) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
 async function findFreePort() {
   const server = net.createServer();
   await new Promise((resolve, reject) => {
@@ -108,34 +109,60 @@ async function findFreePort() {
   return address.port;
 }
 
-async function waitForReady(port, deadlineMs) {
+export function resolveOpenClawLaunch(repoRoot) {
+  // The workflow builds once before measurement. Bypass the mutable source runner so
+  // the timed probe uses that exact dist and cannot refresh plugin inputs at startup.
+  return {
+    command: process.execPath,
+    args: [path.join(repoRoot, "openclaw.mjs")],
+  };
+}
+
+export async function prepareBenchmarkConfig(tempDir) {
+  const configPath = path.join(tempDir, "openclaw.json");
+  // Local RPC RTT must not include hosted model-catalog network latency.
+  await fs.writeFile(
+    configPath,
+    `${JSON.stringify({ models: { catalogRefresh: { enabled: false } } }, null, 2)}\n`,
+  );
+  return configPath;
+}
+
+async function waitForReady(port, deadlineMs, { signal } = {}) {
   const url = `http://127.0.0.1:${port}/readyz`;
   let lastError;
   while (Date.now() < deadlineMs) {
     try {
-      const response = await fetch(url);
+      const response = await fetch(url, { signal });
       if (response.ok) {
         return;
       }
       lastError = new Error(`${url} returned ${response.status}`);
     } catch (error) {
+      if (signal?.aborted) {
+        throw signal.reason;
+      }
       lastError = error;
     }
-    await wait(150);
+    await wait(150, undefined, { signal });
   }
   throw new Error(
     `Gateway did not become ready: ${lastError instanceof Error ? lastError.message : String(lastError)}`,
   );
 }
 
-async function spawnGateway({ repoRoot, outputDir, tempDir, port, token }) {
-  const stdout = await fs.open(path.join(outputDir, "gateway.stdout.log"), "a");
-  const stderr = await fs.open(path.join(outputDir, "gateway.stderr.log"), "a");
+async function spawnGateway({ repoRoot, outputDir, tempDir, configPath, port, token }) {
+  const stdoutPath = path.join(outputDir, "gateway.stdout.log");
+  const stderrPath = path.join(outputDir, "gateway.stderr.log");
+  const stderrOffset = (await fs.stat(stderrPath).catch(() => ({ size: 0 }))).size;
+  const stdout = await fs.open(stdoutPath, "a");
+  const stderr = await fs.open(stderrPath, "a");
+  const launcher = resolveOpenClawLaunch(repoRoot);
   try {
-    return spawn(
-      "pnpm",
+    const child = spawn(
+      launcher.command,
       [
-        "openclaw",
+        ...launcher.args,
         "gateway",
         "run",
         "--port",
@@ -154,7 +181,7 @@ async function spawnGateway({ repoRoot, outputDir, tempDir, port, token }) {
           XDG_CONFIG_HOME: path.join(tempDir, "xdg-config"),
           XDG_CACHE_HOME: path.join(tempDir, "xdg-cache"),
           XDG_DATA_HOME: path.join(tempDir, "xdg-data"),
-          OPENCLAW_CONFIG_PATH: path.join(tempDir, "openclaw.json"),
+          OPENCLAW_CONFIG_PATH: configPath,
           OPENCLAW_STATE_DIR: path.join(tempDir, "state"),
           OPENCLAW_GATEWAY_TOKEN: token,
           OPENCLAW_SKIP_CHANNELS: "1",
@@ -165,9 +192,71 @@ async function spawnGateway({ repoRoot, outputDir, tempDir, port, token }) {
         stdio: ["ignore", stdout.fd, stderr.fd],
       },
     );
+    return { child, stderrOffset, stderrPath };
   } finally {
     await Promise.all([stdout.close(), stderr.close()]);
   }
+}
+
+async function readGatewayStderr(gateway) {
+  const contents = await fs.readFile(gateway.stderrPath);
+  return contents.subarray(gateway.stderrOffset).toString("utf8");
+}
+
+export class GatewayExitedBeforeReadyError extends Error {
+  constructor({ code, signal, stderr, cause }) {
+    const exit = signal ? `signal ${signal}` : `code ${code ?? "unknown"}`;
+    const diagnostic = stderr.trim();
+    super(
+      `Gateway exited before readiness (${exit})${diagnostic ? `:\n${diagnostic}` : ""}`,
+      cause ? { cause } : undefined,
+    );
+    this.name = "GatewayExitedBeforeReadyError";
+    this.code = code;
+    this.signal = signal;
+    this.stderr = stderr;
+  }
+}
+
+export async function waitForGatewayReady(
+  gateway,
+  port,
+  deadlineMs,
+  { readGatewayStderrFn = readGatewayStderr, waitForReadyFn = waitForReady } = {},
+) {
+  const readinessAbort = new AbortController();
+  const exitAbort = new AbortController();
+  const ready = waitForReadyFn(port, deadlineMs, { signal: readinessAbort.signal }).then(
+    () => ({ kind: "ready" }),
+    (error) => ({ error, kind: "ready-error" }),
+  );
+  const exited =
+    gateway.child.exitCode !== null || gateway.child.signalCode !== null
+      ? Promise.resolve({
+          kind: "exit",
+          result: { code: gateway.child.exitCode, signal: gateway.child.signalCode },
+        })
+      : once(gateway.child, "exit", { signal: exitAbort.signal }).then(
+          ([code, signal]) => ({ kind: "exit", result: { code, signal } }),
+          (error) => ({ error, kind: "exit-error" }),
+        );
+  const outcome = await Promise.race([ready, exited]);
+  if (outcome.kind === "ready") {
+    exitAbort.abort();
+    return;
+  }
+  if (outcome.kind === "ready-error") {
+    exitAbort.abort();
+    throw outcome.error;
+  }
+  readinessAbort.abort(new Error("Gateway process exited before readiness."));
+  const stderr = await readGatewayStderrFn(gateway);
+  throw new GatewayExitedBeforeReadyError({
+    code: outcome.result?.code ?? gateway.child.exitCode,
+    signal: outcome.result?.signal ?? gateway.child.signalCode,
+    stderr,
+    cause: outcome.error,
+  });
 }
 
 async function stopGateway(child) {
@@ -221,26 +310,28 @@ async function connectGateway({ GatewayClient, port, token }) {
   return client;
 }
 
-async function timeGatewayRequest(client, method) {
+async function timeGatewayRequest(client, method, timeoutMs) {
   const startedAt = performance.now();
-  await client.request(method, method === "config.get" ? {} : undefined, { timeoutMs: 10_000 });
+  await client.request(method, method === "config.get" ? {} : undefined, { timeoutMs });
   return Math.max(0, Math.round(performance.now() - startedAt));
 }
 
-async function measureMethod(client, method, iterations, warmups) {
+export async function measureMethod(client, method, iterations, warmups) {
   const warmupSamples = [];
   const samples = [];
   const failures = [];
   for (let index = 0; index < warmups; index += 1) {
     try {
-      warmupSamples.push(await timeGatewayRequest(client, method));
+      // Gateway readiness precedes background runtime pre-warming. Give only the
+      // untimed warmup enough budget to cross that startup boundary.
+      warmupSamples.push(await timeGatewayRequest(client, method, WARMUP_TIMEOUT_MS));
     } catch (error) {
       failures.push(error instanceof Error ? error.message : String(error));
     }
   }
   for (let index = 0; index < iterations; index += 1) {
     try {
-      samples.push(await timeGatewayRequest(client, method));
+      samples.push(await timeGatewayRequest(client, method, REQUEST_TIMEOUT_MS));
     } catch (error) {
       failures.push(error instanceof Error ? error.message : String(error));
     }
@@ -254,6 +345,7 @@ async function main() {
   const outputDir = path.resolve(args.outputDir);
   await fs.mkdir(outputDir, { recursive: true });
   const tempDir = await fs.mkdtemp(path.join(outputDir, "..", ".rpc-rtt-"));
+  const configPath = await prepareBenchmarkConfig(tempDir);
   const token = `rtt-${randomUUID()}`;
   const port = await findFreePort();
   const startedAt = new Date();
@@ -265,8 +357,9 @@ async function main() {
   const methodResults = [];
 
   try {
-    gatewayChild = await spawnGateway({ repoRoot, outputDir, tempDir, port, token });
-    await waitForReady(port, Date.now() + 45_000);
+    const gateway = await spawnGateway({ repoRoot, outputDir, tempDir, configPath, port, token });
+    gatewayChild = gateway.child;
+    await waitForGatewayReady(gateway, port, Date.now() + 45_000);
     const { GatewayClient } = await loadGatewayClient(repoRoot);
     const connectStartedAt = performance.now();
     client = await connectGateway({ GatewayClient, port, token });
@@ -366,7 +459,9 @@ async function main() {
   }
 }
 
-main().catch((error) => {
-  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
-  process.exitCode = 1;
-});
+if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {
+  main().catch((error) => {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/measure-rpc-rtt.mjs
+++ b/scripts/measure-rpc-rtt.mjs
@@ -282,7 +282,7 @@ async function loadGatewayClient(repoRoot) {
   return await import(clientUrl);
 }
 
-async function connectGateway({ GatewayClient, port, token }) {
+export async function connectGateway({ GatewayClient, port, token }) {
   let client;
   const connected = new Promise((resolve, reject) => {
     client = new GatewayClient({
@@ -294,7 +294,7 @@ async function connectGateway({ GatewayClient, port, token }) {
       platform: process.platform,
       mode: "backend",
       role: "operator",
-      scopes: ["operator.admin"],
+      scopes: ["operator.read"],
       requestTimeoutMs: 10_000,
       connectChallengeTimeoutMs: 10_000,
       env: {
@@ -322,8 +322,7 @@ export async function measureMethod(client, method, iterations, warmups) {
   const failures = [];
   for (let index = 0; index < warmups; index += 1) {
     try {
-      // Gateway readiness precedes background runtime pre-warming. Give only the
-      // untimed warmup enough budget to cross that startup boundary.
+      // Keep startup variance out of measured samples while bounding the untimed warmup.
       warmupSamples.push(await timeGatewayRequest(client, method, WARMUP_TIMEOUT_MS));
     } catch (error) {
       failures.push(error instanceof Error ? error.message : String(error));

--- a/scripts/measure-rpc-rtt.test.mjs
+++ b/scripts/measure-rpc-rtt.test.mjs
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+import {
+  GatewayExitedBeforeReadyError,
+  measureMethod,
+  prepareBenchmarkConfig,
+  resolveOpenClawLaunch,
+  waitForGatewayReady,
+} from "./measure-rpc-rtt.mjs";
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+test("launches the built OpenClaw entry without the mutable source runner", () => {
+  assert.deepEqual(resolveOpenClawLaunch("/repo"), {
+    command: process.execPath,
+    args: [path.join("/repo", "openclaw.mjs")],
+  });
+});
+
+test("disables hosted model catalog traffic for local RPC measurement", async (t) => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-rtt-config-"));
+  t.after(() => fs.rm(tempDir, { force: true, recursive: true }));
+
+  const configPath = await prepareBenchmarkConfig(tempDir);
+  const contents = await fs.readFile(configPath, "utf8");
+
+  assert.deepEqual(JSON.parse(contents), {
+    models: { catalogRefresh: { enabled: false } },
+  });
+  assert.equal(
+    contents,
+    '{\n  "models": {\n    "catalogRefresh": {\n      "enabled": false\n    }\n  }\n}\n',
+  );
+});
+
+test("observes gateway exit without waiting for the readiness deadline", async () => {
+  const child = new EventEmitter();
+  child.exitCode = null;
+  child.signalCode = null;
+  const startedAt = Date.now();
+  setImmediate(() => {
+    child.exitCode = 1;
+    child.emit("exit", 1, null);
+  });
+
+  await assert.rejects(
+    waitForGatewayReady(
+      { child },
+      18789,
+      Date.now() + 45_000,
+      {
+        readGatewayStderrFn: async () => "startup failed\n",
+        waitForReadyFn: async (_port, _deadlineMs, { signal }) =>
+          await new Promise((_, reject) => {
+            signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+          }),
+      },
+    ),
+    (error) => {
+      assert.equal(error.code, 1);
+      assert.equal(error.stderr, "startup failed\n");
+      return true;
+    },
+  );
+  assert.ok(Date.now() - startedAt < 1_000);
+});
+
+test("uses a startup budget only for untimed warmup requests", async () => {
+  const timeouts = [];
+  const client = {
+    request: async (_method, _params, options) => {
+      timeouts.push(options.timeoutMs);
+    },
+  };
+
+  const result = await measureMethod(client, "health", 2, 1);
+
+  assert.deepEqual(timeouts, [30_000, 10_000, 10_000]);
+  assert.deepEqual(result.failures, []);
+  assert.equal(result.warmupSamples.length, 1);
+  assert.equal(result.samples.length, 2);
+});
+
+test("main surface workflow builds once outside the timed samples", async () => {
+  const workflow = await fs.readFile(
+    path.join(REPO_ROOT, ".github/workflows/main-surface-rtt.yml"),
+    "utf8",
+  );
+  const rpcStep = workflow.slice(
+    workflow.indexOf("- name: Run RPC RTT samples"),
+    workflow.indexOf("- name: Upload RPC RTT artifacts"),
+  );
+  assert.equal((workflow.match(/\n\s+pnpm build\n/gu) ?? []).length, 1);
+  assert.ok(workflow.indexOf("pnpm build") < workflow.indexOf("Run RPC RTT samples"));
+  assert.match(rpcStep, /echo "attempts=1" >>"\$metrics_path"/u);
+});

--- a/scripts/measure-rpc-rtt.test.mjs
+++ b/scripts/measure-rpc-rtt.test.mjs
@@ -6,6 +6,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import test from "node:test";
 import {
+  connectGateway,
   GatewayExitedBeforeReadyError,
   measureMethod,
   prepareBenchmarkConfig,
@@ -14,6 +15,29 @@ import {
 } from "./measure-rpc-rtt.mjs";
 
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+test("connects with the least-privilege read scope", async () => {
+  let options;
+  class FakeGatewayClient {
+    constructor(receivedOptions) {
+      options = receivedOptions;
+    }
+
+    start() {
+      options.onHelloOk();
+    }
+  }
+
+  const client = await connectGateway({
+    GatewayClient: FakeGatewayClient,
+    port: 18789,
+    token: "test-token",
+  });
+
+  assert.ok(client instanceof FakeGatewayClient);
+  assert.deepEqual(options.scopes, ["operator.read"]);
+  assert.equal(options.scopes.includes("operator.admin"), false);
+});
 
 test("launches the built OpenClaw entry without the mutable source runner", () => {
   assert.deepEqual(resolveOpenClawLaunch("/repo"), {


### PR DESCRIPTION
## What Problem This Solves

Main Surface RTT timing included OpenClaw's mutable source runner, waited the full readiness deadline when the gateway exited early, and allowed hosted model-catalog traffic to contaminate local `config.get` latency. The RPC probe also requested `operator.admin` even though both measured methods, `health` and `config.get`, require only `operator.read`.

## Why This Change Was Made

The workflow builds OpenClaw once before timed samples, and the probe launches that exact built distribution through `node openclaw.mjs`. Readiness races the gateway process exit so startup failures report immediately with the current attempt's stderr instead of waiting 45 seconds.

The probe writes one deterministic benchmark config with `models.catalogRefresh.enabled: false`, keeping hosted catalog traffic outside local RTT. It performs one bounded untimed warmup per method, keeps every measured request on the strict 10-second timeout, and now connects with the least-privilege `operator.read` scope required by both measured methods. No retry was added.

The earlier migration-convergence retry workaround remains removed. OpenClaw fixed that producer at `9371dddcdbe22fb4b68a4a0eab5eafad7a529038`.

Non-test delta: `+129/-27` (net `+102`). This is justified by the deterministic process-lifecycle and measurement boundary. Tests: `+125`.

## User Impact

Main Surface RTT measures a prebuilt OpenClaw process, excludes build/source-runner mutation and hosted catalog traffic from timed samples, uses the correct read-only authorization surface, and reports genuine startup exits promptly.

## Evidence

- `npm test` - 88/88 passed.
- `npm run check` - syntax, data validation, and README generation passed.
- Focused measurement tests - 6/6 passed, including exact `operator.read` scope and no `operator.admin`.
- Current OpenClaw contract at `13523321b315f146eeeb5534e9394643b7ac908c`: `health` and `config.get` are both registered with `operator.read`.
- Previous failing exact-head run: https://github.com/openclaw/openclaw-rtt/actions/runs/30977837119
- Core producer fix: https://github.com/openclaw/openclaw/commit/9371dddcdbe22fb4b68a4a0eab5eafad7a529038
- Hosted-catalog evidence: https://github.com/openclaw/openclaw-rtt/actions/runs/30973268589

Punchcard compliance finding: commit and PR attestations return `INVALID_INPUT` because the active long-running session was registered from another `openclaw/*` repository. The original commit retains `Punchcard-Session: amber-orchard-valley-s4`; no PR receipt marker was issued.
