### PR TITLE
chore: add MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 OpenClaw Foundation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## What Problem This Solves

The repository currently has no root license, leaving its reuse terms unspecified.

## Why This Change Was Made

Adds the standard MIT license with copyright assigned to the OpenClaw Foundation.
The change is intentionally limited to the root `LICENSE` file.

## User Impact

Users and contributors can clearly understand the repository's MIT licensing terms.
There are no runtime, package, configuration, documentation, workflow, or source changes.

## Evidence

- Confirmed the repository is public, active, and had no root license on the audited `main` head.
- `git diff --check` passed.
- The commit contains one added file: `LICENSE` (`+21/-0`).
- Privacy scan passed; no personal paths, private hosts, IPs, emails, or credentials are present.
- Tests were not run because this is a license-only metadata change.
