### PR TITLE
chore(ci): update GitHub Actions contracts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: 24
 

--- a/.github/workflows/crabbox-hydrate.yml
+++ b/.github/workflows/crabbox-hydrate.yml
@@ -43,11 +43,11 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.ref }}
 
-      - uses: pnpm/action-setup@v6.0.9
+      - uses: pnpm/action-setup@v6.0.10
         with:
           version: ${{ env.PNPM_VERSION }}
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
 

--- a/.github/workflows/main-channel-rtt.yml
+++ b/.github/workflows/main-channel-rtt.yml
@@ -115,7 +115,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
 
@@ -336,7 +336,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
 

--- a/.github/workflows/main-discord-rtt.yml
+++ b/.github/workflows/main-discord-rtt.yml
@@ -46,7 +46,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
 

--- a/.github/workflows/main-rtt.yml
+++ b/.github/workflows/main-rtt.yml
@@ -45,12 +45,12 @@ jobs:
           persist-credentials: false
 
       - name: Set up Blacksmith Docker Builder
-        uses: useblacksmith/setup-docker-builder@ab5c1da94f53f5cd75c1038092aa276dddfccbba # v1
+        uses: useblacksmith/setup-docker-builder@a5256a73e30f09e37e3eceb8ca36043d17621d24 # v2
         with:
-          max-cache-size-mb: 800000
+          cache-key: openclaw-rtt-main-telegram
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
 

--- a/.github/workflows/main-surface-rtt.yml
+++ b/.github/workflows/main-surface-rtt.yml
@@ -58,7 +58,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
 

--- a/.github/workflows/readme-hydration.yml
+++ b/.github/workflows/readme-hydration.yml
@@ -54,7 +54,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
 

--- a/.github/workflows/release-channel-rtt.yml
+++ b/.github/workflows/release-channel-rtt.yml
@@ -59,7 +59,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
 
@@ -120,7 +120,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
 
@@ -386,7 +386,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
 

--- a/.github/workflows/release-surface-rtt.yml
+++ b/.github/workflows/release-surface-rtt.yml
@@ -52,7 +52,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
 
@@ -103,7 +103,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
 
@@ -245,7 +245,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
 

--- a/.github/workflows/stable-release-discord-rtt.yml
+++ b/.github/workflows/stable-release-discord-rtt.yml
@@ -55,7 +55,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
 
@@ -116,7 +116,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
 
@@ -332,7 +332,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
 

--- a/.github/workflows/stable-release-rtt.yml
+++ b/.github/workflows/stable-release-rtt.yml
@@ -54,7 +54,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
 
@@ -88,9 +88,9 @@ jobs:
 
       - name: Set up Blacksmith Docker Builder
         if: steps.release.outputs.should_run == 'true'
-        uses: useblacksmith/setup-docker-builder@ab5c1da94f53f5cd75c1038092aa276dddfccbba # v1
+        uses: useblacksmith/setup-docker-builder@a5256a73e30f09e37e3eceb8ca36043d17621d24 # v2
         with:
-          max-cache-size-mb: 800000
+          cache-key: openclaw-rtt-release-telegram
 
       - name: Setup pnpm
         if: steps.release.outputs.should_run == 'true'


### PR DESCRIPTION
Supersedes #34.

## What Problem This Solves

Resolves a problem where the pending grouped GitHub Actions update could not be landed safely because the Blacksmith Docker Builder v2 action requires a cache key and no longer supports the v1 cache-size input.

## Why This Change Was Made

This carries forward the valid `actions/setup-node` v7 and `pnpm/action-setup` v6.0.10 updates, then completes the Blacksmith v2 migration with distinct stable cache identities for main and release Telegram RTT jobs.

## User Impact

There is no product behavior change. RTT automation uses supported Node 24 action runtimes and preserves separate Docker layer caches for main and release measurements.

## Evidence

- `npm test`: 81 passed
- `npm run check`: passed
- `actionlint`: passed
- `git diff --check origin/main...HEAD`: passed
- TruffleHog: clean
- Autoreview: clean, no accepted/actionable findings
- Upstream Blacksmith v2 contract requires `cache-key`: https://github.com/useblacksmith/setup-docker-builder/blob/v2.1.0/action.yml
