### PR TITLE
fix: post-release packages fail RTT selection

### DIFF
--- a/.github/workflows/readme-hydration.yml
+++ b/.github/workflows/readme-hydration.yml
@@ -10,6 +10,7 @@ on:
       - "runs/**"
       - "scripts/channel-rtt-summary.mjs"
       - "scripts/discord-rtt-summary.mjs"
+      - "scripts/openclaw-version.mjs"
       - "scripts/read-channel-rtt-rows.mjs"
       - "scripts/read-discord-rtt-rows.mjs"
       - "scripts/read-rows.mjs"

--- a/scripts/openclaw-version.mjs
+++ b/scripts/openclaw-version.mjs
@@ -1,0 +1,56 @@
+const OPENCLAW_VERSION_RE =
+  /^(?<major>[0-9]{4})\.(?<minor>[1-9][0-9]*)\.(?<patch>[1-9][0-9]*)(?:(?:-beta\.(?<beta>[1-9][0-9]*))|(?:-(?<post>[1-9][0-9]*)))?$/u;
+
+export function parseOpenClawVersion(version) {
+  const match = OPENCLAW_VERSION_RE.exec(version);
+  if (!match?.groups) {
+    return undefined;
+  }
+
+  const kind = match.groups.beta ? "beta" : match.groups.post ? "post" : "stable";
+  return {
+    version,
+    major: Number(match.groups.major),
+    minor: Number(match.groups.minor),
+    patch: Number(match.groups.patch),
+    kind,
+    releaseNumber: Number(match.groups.beta ?? match.groups.post ?? 0),
+  };
+}
+
+function versionOrder(version) {
+  const parsed = parseOpenClawVersion(version);
+  if (!parsed) {
+    return undefined;
+  }
+  const releaseRank = parsed.kind === "beta" ? 0 : parsed.kind === "stable" ? 1 : 2;
+  return [parsed.major, parsed.minor, parsed.patch, releaseRank, parsed.releaseNumber];
+}
+
+export function compareOpenClawVersions(left, right) {
+  const leftParts = versionOrder(left);
+  const rightParts = versionOrder(right);
+  if (!leftParts || !rightParts) {
+    throw new Error(`Cannot compare unsupported versions: ${left}, ${right}`);
+  }
+  for (let index = 0; index < leftParts.length; index += 1) {
+    const difference = leftParts[index] - rightParts[index];
+    if (difference !== 0) {
+      return difference;
+    }
+  }
+  return 0;
+}
+
+export function isStableOpenClawVersion(version) {
+  const parsed = parseOpenClawVersion(version);
+  return parsed?.kind === "stable" || parsed?.kind === "post";
+}
+
+export function isOpenClawReleaseSpec(spec) {
+  return (
+    typeof spec === "string" &&
+    spec.startsWith("openclaw@") &&
+    parseOpenClawVersion(spec.slice("openclaw@".length)) !== undefined
+  );
+}

--- a/scripts/openclaw-version.test.mjs
+++ b/scripts/openclaw-version.test.mjs
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  compareOpenClawVersions,
+  isOpenClawReleaseSpec,
+  isStableOpenClawVersion,
+  parseOpenClawVersion,
+} from "./openclaw-version.mjs";
+
+test("parses beta, stable, and numeric post-release versions", () => {
+  assert.deepEqual(parseOpenClawVersion("2026.7.1-beta.4"), {
+    version: "2026.7.1-beta.4",
+    major: 2026,
+    minor: 7,
+    patch: 1,
+    kind: "beta",
+    releaseNumber: 4,
+  });
+  assert.equal(parseOpenClawVersion("2026.7.1")?.kind, "stable");
+  assert.deepEqual(parseOpenClawVersion("2026.7.1-2"), {
+    version: "2026.7.1-2",
+    major: 2026,
+    minor: 7,
+    patch: 1,
+    kind: "post",
+    releaseNumber: 2,
+  });
+});
+
+test("orders beta before stable and numeric post releases", () => {
+  const versions = ["2026.7.1-2", "2026.7.1", "2026.7.1-beta.4", "2026.7.1-1"];
+  assert.deepEqual(versions.sort(compareOpenClawVersions), [
+    "2026.7.1-beta.4",
+    "2026.7.1",
+    "2026.7.1-1",
+    "2026.7.1-2",
+  ]);
+});
+
+test("treats stable and numeric post releases as stable", () => {
+  assert.equal(isStableOpenClawVersion("2026.7.1-beta.4"), false);
+  assert.equal(isStableOpenClawVersion("2026.7.1"), true);
+  assert.equal(isStableOpenClawVersion("2026.7.1-1"), true);
+});
+
+test("accepts only exact OpenClaw release specs", () => {
+  assert.equal(isOpenClawReleaseSpec("openclaw@2026.7.1-beta.4"), true);
+  assert.equal(isOpenClawReleaseSpec("openclaw@2026.7.1"), true);
+  assert.equal(isOpenClawReleaseSpec("openclaw@2026.7.1-2"), true);
+  assert.equal(isOpenClawReleaseSpec("openclaw@main"), false);
+  assert.equal(isOpenClawReleaseSpec("other@2026.7.1-2"), false);
+});
+
+test("rejects unsupported or non-canonical versions", () => {
+  for (const version of [
+    "2026.7.1-alpha.1",
+    "2026.7.1-beta.0",
+    "2026.7.1-beta.01",
+    "2026.7.1-0",
+    "2026.7.1-01",
+    "2026.7.1-rc.1",
+    "2026.07.1",
+    "2026.7.01",
+  ]) {
+    assert.equal(parseOpenClawVersion(version), undefined);
+  }
+  assert.throws(
+    () => compareOpenClawVersions("2026.7.1", "2026.7.1-rc.1"),
+    /Cannot compare unsupported versions/u,
+  );
+});

--- a/scripts/readme-hydration-workflow.test.mjs
+++ b/scripts/readme-hydration-workflow.test.mjs
@@ -1,0 +1,13 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const WORKFLOW_PATH = path.join(REPO_ROOT, ".github/workflows/readme-hydration.yml");
+
+test("README hydration runs when the shared OpenClaw version contract changes", async () => {
+  const workflow = await fs.readFile(WORKFLOW_PATH, "utf8");
+  assert.match(workflow, /- "scripts\/openclaw-version\.mjs"/u);
+});

--- a/scripts/release-qa-config-compat.mjs
+++ b/scripts/release-qa-config-compat.mjs
@@ -4,12 +4,13 @@ const LEGACY_CONFIG_CUTOFF = {
   major: 2026,
   minor: 7,
   patch: 2,
-  prerelease: 4,
+  releaseRank: 0,
+  releaseNumber: 4,
 };
 
 function parseExactPackageVersion(packageSpec) {
   const match =
-    /^openclaw@(?<version>(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)(?:-beta\.(?<prerelease>\d+))?)$/u.exec(
+    /^openclaw@(?<version>(?<major>[0-9]{4})\.(?<minor>[1-9][0-9]*)\.(?<patch>[1-9][0-9]*)(?:(?:-beta\.(?<beta>[1-9][0-9]*))|(?:-(?<post>[1-9][0-9]*)))?)$/u.exec(
       packageSpec ?? "",
     );
   if (!match?.groups) {
@@ -20,15 +21,13 @@ function parseExactPackageVersion(packageSpec) {
     major: Number(match.groups.major),
     minor: Number(match.groups.minor),
     patch: Number(match.groups.patch),
-    prerelease:
-      match.groups.prerelease === undefined
-        ? Number.POSITIVE_INFINITY
-        : Number(match.groups.prerelease),
+    releaseRank: match.groups.beta ? 0 : match.groups.post ? 2 : 1,
+    releaseNumber: Number(match.groups.beta ?? match.groups.post ?? 0),
   };
 }
 
 function compareVersions(left, right) {
-  for (const key of ["major", "minor", "patch", "prerelease"]) {
+  for (const key of ["major", "minor", "patch", "releaseRank", "releaseNumber"]) {
     const difference = left[key] - right[key];
     if (difference !== 0) {
       return difference;

--- a/scripts/release-qa-config-compat.test.mjs
+++ b/scripts/release-qa-config-compat.test.mjs
@@ -61,19 +61,51 @@ test("preserves current config shape while stamping beta releases", () => {
   });
 });
 
+test("adapts historical numeric post releases before the config cutoff", () => {
+  const config = currentConfig();
+  const adapted = adaptReleaseGatewayConfig(config, "openclaw@2026.7.1-2");
+
+  assert.deepEqual(adapted.meta, { lastTouchedVersion: "2026.7.1-2" });
+  assert.deepEqual(adapted.agents, {
+    defaults: { workspace: "/tmp/qa" },
+    list: [
+      {
+        default: true,
+        id: "qa",
+        model: "mock-openai/qa",
+      },
+    ],
+  });
+  assert.deepEqual(adapted.memory, { backend: "builtin" });
+});
+
+test("preserves current config shape for numeric post releases after the cutoff", () => {
+  const config = currentConfig();
+  const adapted = adaptReleaseGatewayConfig(config, "openclaw@2026.7.2-1");
+
+  assert.deepEqual(adapted, {
+    ...config,
+    meta: { lastTouchedVersion: "2026.7.2-1" },
+  });
+});
+
 test("selects the candidate auth runtime only for exact release specs", () => {
   const runtimePath = "/tmp/openclaw/dist/plugin-sdk/agent-runtime.js";
   assert.equal(
     resolveReleaseAuthRuntimePath("openclaw@2026.7.2-beta.4", runtimePath),
     runtimePath,
   );
+  assert.equal(resolveReleaseAuthRuntimePath("openclaw@2026.7.1-2", runtimePath), runtimePath);
   assert.equal(resolveReleaseAuthRuntimePath("openclaw@main", runtimePath), undefined);
   assert.equal(resolveReleaseAuthRuntimePath("other@2026.7.2", runtimePath), undefined);
+  assert.equal(resolveReleaseAuthRuntimePath("openclaw@2026.7.1-0", runtimePath), undefined);
+  assert.equal(resolveReleaseAuthRuntimePath("openclaw@2026.7.1-rc.1", runtimePath), undefined);
   assert.equal(resolveReleaseAuthRuntimePath("openclaw@2026.7.2", ""), undefined);
 });
 
 test("leaves non-release configs untouched", () => {
   const config = currentConfig();
   assert.strictEqual(adaptReleaseGatewayConfig(config, "openclaw@main"), config);
+  assert.strictEqual(adaptReleaseGatewayConfig(config, "openclaw@2026.7.1-rc.1"), config);
   assert.strictEqual(adaptReleaseGatewayConfig(config, undefined), config);
 });

--- a/scripts/resolve-openclaw-channel-package.mjs
+++ b/scripts/resolve-openclaw-channel-package.mjs
@@ -2,52 +2,24 @@ import { execFile } from "node:child_process";
 import fs from "node:fs/promises";
 import { promisify } from "node:util";
 import { listChannelRttChannels } from "./channel-rtt-config.mjs";
+import {
+  compareOpenClawVersions,
+  isOpenClawReleaseSpec,
+  parseOpenClawVersion,
+} from "./openclaw-version.mjs";
 import { readChannelRttRows } from "./read-channel-rtt-rows.mjs";
 import { readRows } from "./read-rows.mjs";
 import { channelReleaseSkipReason } from "./release-gap-reasons.mjs";
 
 const execFileAsync = promisify(execFile);
-const RELEASE_SPEC_RE =
-  /^openclaw@[0-9]{4}\.[1-9][0-9]*\.[1-9][0-9]*(?:-beta\.[1-9][0-9]*)?$/u;
-const STABLE_VERSION_RE = /^([0-9]{4})\.([1-9][0-9]*)\.([1-9][0-9]*)$/u;
-const BETA_VERSION_RE = /^([0-9]{4})\.([1-9][0-9]*)\.([1-9][0-9]*)-beta\.([1-9][0-9]*)$/u;
 const DEFAULT_CHANNELS = ["slack", "whatsapp"];
 const DEFAULT_VERSION_LIMIT = 4;
 const CHANNEL_RELEASE_MIN_VERSION = "2026.4.24";
 
-function parseVersion(version) {
-  const stableMatch = STABLE_VERSION_RE.exec(version);
-  if (stableMatch) {
-    return [...stableMatch.slice(1).map(Number), Number.MAX_SAFE_INTEGER];
-  }
-
-  const betaMatch = BETA_VERSION_RE.exec(version);
-  if (betaMatch) {
-    return betaMatch.slice(1).map(Number);
-  }
-
-  return undefined;
-}
-
-function compareVersions(left, right) {
-  const leftParts = parseVersion(left);
-  const rightParts = parseVersion(right);
-  if (!leftParts || !rightParts) {
-    throw new Error(`Cannot compare unsupported versions: ${left}, ${right}`);
-  }
-  for (let index = 0; index < leftParts.length; index += 1) {
-    const diff = leftParts[index] - rightParts[index];
-    if (diff !== 0) {
-      return diff;
-    }
-  }
-  return 0;
-}
-
 async function npmVersions() {
   const fixture = process.env.INPUT_AVAILABLE_VERSIONS;
   if (fixture) {
-    return new Set(readList(fixture).filter((version) => parseVersion(version)));
+    return new Set(readList(fixture).filter((version) => parseOpenClawVersion(version)));
   }
   const { stdout } = await execFileAsync("npm", ["view", "openclaw", "versions", "--json"], {
     timeout: 30_000,
@@ -56,7 +28,9 @@ async function npmVersions() {
   if (!Array.isArray(parsed)) {
     throw new Error("npm view openclaw versions --json must return an array.");
   }
-  return new Set(parsed.filter((version) => typeof version === "string" && parseVersion(version)));
+  return new Set(
+    parsed.filter((version) => typeof version === "string" && parseOpenClawVersion(version)),
+  );
 }
 
 function readList(value) {
@@ -88,9 +62,9 @@ function releaseRows(rows) {
   return rows.filter(
     (row) =>
       typeof row.package?.spec === "string" &&
-      RELEASE_SPEC_RE.test(row.package.spec) &&
+      isOpenClawReleaseSpec(row.package.spec) &&
       typeof row.package?.version === "string" &&
-      parseVersion(row.package.version),
+      parseOpenClawVersion(row.package.version),
   );
 }
 
@@ -140,8 +114,8 @@ for (const channelId of channelIds) {
     .filter((row) => row.channel?.id === channelId)
     .filter((row) => row.run?.status === "pass")
     .map((row) => row.package.version)
-    .filter((version) => parseVersion(version));
-  const latestMeasured = measuredVersions.sort(compareVersions).at(-1);
+    .filter((version) => parseOpenClawVersion(version));
+  const latestMeasured = measuredVersions.sort(compareOpenClawVersions).at(-1);
   const versions =
     explicitVersions.length > 0
       ? explicitVersions
@@ -150,11 +124,11 @@ for (const channelId of channelIds) {
             (version) =>
               baselineVersions.has(version) ||
               !latestMeasured ||
-              compareVersions(version, latestMeasured) > 0,
+              compareOpenClawVersions(version, latestMeasured) > 0,
           )
           .filter(
             (version) =>
-              compareVersions(version, CHANNEL_RELEASE_MIN_VERSION) >= 0 &&
+              compareOpenClawVersions(version, CHANNEL_RELEASE_MIN_VERSION) >= 0 &&
               !measured.has(`${channelId}\0openclaw@${version}\0${version}`) &&
               !channelReleaseSkipReason(channel, version),
           )
@@ -165,12 +139,13 @@ for (const channelId of channelIds) {
             const rightAttempted = attempted.has(
               `${channelId}\0openclaw@${right}\0${right}`,
             );
-            return Number(leftAttempted) - Number(rightAttempted) || compareVersions(left, right);
+            const attemptDiff = Number(leftAttempted) - Number(rightAttempted);
+            return attemptDiff || compareOpenClawVersions(left, right);
           })
           .slice(0, versionLimit);
 
   for (const version of versions) {
-    if (!parseVersion(version)) {
+    if (!parseOpenClawVersion(version)) {
       throw new Error(`Unsupported version: ${version}`);
     }
     if (!availableVersions.has(version)) {
@@ -213,7 +188,7 @@ queue.sort((left, right) => {
       return attemptDiff;
     }
   }
-  const versionDiff = compareVersions(left.version, right.version);
+  const versionDiff = compareOpenClawVersions(left.version, right.version);
   if (versionDiff !== 0) {
     return versionDiff;
   }

--- a/scripts/resolve-openclaw-channel-package.test.mjs
+++ b/scripts/resolve-openclaw-channel-package.test.mjs
@@ -265,3 +265,32 @@ test("skips proven historical channel release gaps", async () => {
     "whatsapp:2026.5.16-beta.3",
   ]);
 });
+
+test("queues explicit numeric post releases for sibling channels", async () => {
+  const workspace = await makeWorkspace();
+  await writeJsonl(path.join(workspace, "data/channels/telegram/2026.7.1-2.jsonl"), [
+    row("2026.7.1-2"),
+  ]);
+
+  const { stdout } = await execFileAsync(process.execPath, [RESOLVE_SCRIPT], {
+    cwd: workspace,
+    env: {
+      ...process.env,
+      GITHUB_OUTPUT: "",
+      INPUT_AVAILABLE_VERSIONS: "2026.7.1-2",
+      INPUT_CHANNELS: "slack whatsapp",
+      INPUT_VERSIONS: "2026.7.1-2",
+    },
+  });
+
+  const outputs = Object.fromEntries(
+    stdout
+      .trim()
+      .split("\n")
+      .map((line) => line.split(/=(.*)/su).slice(0, 2)),
+  );
+  assert.deepEqual(
+    JSON.parse(outputs.matrix).map((entry) => `${entry.channel}:${entry.version}`),
+    ["slack:2026.7.1-2", "whatsapp:2026.7.1-2"],
+  );
+});

--- a/scripts/resolve-openclaw-discord-package.mjs
+++ b/scripts/resolve-openclaw-discord-package.mjs
@@ -1,44 +1,18 @@
 import { execFile } from "node:child_process";
 import fs from "node:fs/promises";
 import { promisify } from "node:util";
+import {
+  compareOpenClawVersions,
+  isOpenClawReleaseSpec,
+  isStableOpenClawVersion,
+  parseOpenClawVersion,
+} from "./openclaw-version.mjs";
 import { readDiscordRttRows } from "./read-discord-rtt-rows.mjs";
 import { readRows } from "./read-rows.mjs";
 import { discordReleaseGapReason } from "./release-gap-reasons.mjs";
 
 const execFileAsync = promisify(execFile);
-const STABLE_VERSION_RE = /^([0-9]{4})\.([1-9][0-9]*)\.([1-9][0-9]*)$/u;
-const BETA_VERSION_RE = /^([0-9]{4})\.([1-9][0-9]*)\.([1-9][0-9]*)-beta\.([1-9][0-9]*)$/u;
-const RELEASE_SPEC_RE =
-  /^openclaw@[0-9]{4}\.[1-9][0-9]*\.[1-9][0-9]*(?:-beta\.[1-9][0-9]*)?$/u;
 const DISCORD_RELEASE_MIN_VERSION = "2026.4.24";
-function parseVersion(version) {
-  const stableMatch = STABLE_VERSION_RE.exec(version);
-  if (stableMatch) {
-    return [...stableMatch.slice(1).map(Number), Number.MAX_SAFE_INTEGER];
-  }
-
-  const betaMatch = BETA_VERSION_RE.exec(version);
-  if (betaMatch) {
-    return betaMatch.slice(1).map(Number);
-  }
-
-  return undefined;
-}
-
-function compareVersions(left, right) {
-  const leftParts = parseVersion(left);
-  const rightParts = parseVersion(right);
-  if (!leftParts || !rightParts) {
-    throw new Error(`Cannot compare unsupported versions: ${left}, ${right}`);
-  }
-  for (let index = 0; index < leftParts.length; index += 1) {
-    const diff = leftParts[index] - rightParts[index];
-    if (diff !== 0) {
-      return diff;
-    }
-  }
-  return 0;
-}
 
 async function npmVersions() {
   const { stdout } = await execFileAsync("npm", ["view", "openclaw", "versions", "--json"], {
@@ -54,16 +28,16 @@ async function npmVersions() {
 function latestReleaseVersion(rows) {
   return rows
     .map((row) => row.package?.version)
-    .filter((version) => typeof version === "string" && parseVersion(version))
-    .sort(compareVersions)
+    .filter((version) => typeof version === "string" && parseOpenClawVersion(version))
+    .sort(compareOpenClawVersions)
     .at(-1);
 }
 
 function latestStableVersion(rows) {
   return rows
     .map((row) => row.package?.version)
-    .filter((version) => typeof version === "string" && STABLE_VERSION_RE.test(version))
-    .sort(compareVersions)
+    .filter((version) => typeof version === "string" && isStableOpenClawVersion(version))
+    .sort(compareOpenClawVersions)
     .at(-1);
 }
 
@@ -75,7 +49,7 @@ function releaseVersionSet(rows) {
   return new Set(
     rows
       .map((row) => row.package?.version)
-      .filter((version) => typeof version === "string" && parseVersion(version)),
+      .filter((version) => typeof version === "string" && parseOpenClawVersion(version)),
   );
 }
 
@@ -83,9 +57,9 @@ function releaseRows(rows) {
   return rows.filter(
     (row) =>
       typeof row.package?.spec === "string" &&
-      RELEASE_SPEC_RE.test(row.package.spec) &&
+      isOpenClawReleaseSpec(row.package.spec) &&
       typeof row.package?.version === "string" &&
-      parseVersion(row.package.version),
+      parseOpenClawVersion(row.package.version),
   );
 }
 
@@ -114,10 +88,10 @@ function readRequestedVersionsEnv(name) {
     ),
   ];
   for (const version of versions) {
-    if (!parseVersion(version)) {
+    if (!parseOpenClawVersion(version)) {
       throw new Error(`${name} contains unsupported OpenClaw version: ${version}`);
     }
-    if (compareVersions(version, DISCORD_RELEASE_MIN_VERSION) < 0) {
+    if (compareOpenClawVersions(version, DISCORD_RELEASE_MIN_VERSION) < 0) {
       throw new Error(
         `${name} contains Discord release version before ${DISCORD_RELEASE_MIN_VERSION}: ${version}`,
       );
@@ -144,7 +118,7 @@ const baselineRows = releaseRows(await readRows());
 const successfulBaselineRows = successfulReleaseRows(baselineRows);
 const baselineVersions = releaseVersionSet(
   successfulBaselineRows.filter(
-    (row) => compareVersions(row.package.version, DISCORD_RELEASE_MIN_VERSION) >= 0,
+    (row) => compareOpenClawVersions(row.package.version, DISCORD_RELEASE_MIN_VERSION) >= 0,
   ),
 );
 const anchor = latestReleaseVersion(successfulDiscordRows) ?? latestStableVersion(successfulBaselineRows);
@@ -165,7 +139,7 @@ if (requestedVersions.length > 0) {
       }
       return { version, spec: `openclaw@${version}`, tag: `v${version}` };
     })
-    .sort((left, right) => compareVersions(left.version, right.version));
+    .sort((left, right) => compareOpenClawVersions(left.version, right.version));
 } else if (rssBackfill) {
   queue = discordRows
     .filter((row) => row.resources?.maxRssKb?.max === undefined)
@@ -174,23 +148,24 @@ if (requestedVersions.length > 0) {
       spec: row.package.spec,
       tag: `v${row.package.version}`,
     }))
-    .sort((left, right) => compareVersions(right.version, left.version))
+    .sort((left, right) => compareOpenClawVersions(right.version, left.version))
     .slice(0, rssBackfillLimit);
 } else {
   const measured = new Set(
     successfulDiscordRows.map((row) => `${row.package.spec}\0${row.package.version}`),
   );
   queue = (await npmVersions())
-    .filter((version) => typeof version === "string" && parseVersion(version))
+    .filter((version) => typeof version === "string" && parseOpenClawVersion(version))
     .map((version) => ({ version, spec: `openclaw@${version}`, tag: `v${version}` }))
-    .filter((pkg) => compareVersions(pkg.version, DISCORD_RELEASE_MIN_VERSION) >= 0)
+    .filter((pkg) => compareOpenClawVersions(pkg.version, DISCORD_RELEASE_MIN_VERSION) >= 0)
     .filter((pkg) => !discordReleaseGapReason(pkg.version))
     .filter((pkg) => !measured.has(`${pkg.spec}\0${pkg.version}`))
     .filter(
       (pkg) =>
-        baselineVersions.has(pkg.version) || compareVersions(pkg.version, anchor) > 0,
+        baselineVersions.has(pkg.version) ||
+        compareOpenClawVersions(pkg.version, anchor) > 0,
     )
-    .sort((left, right) => compareVersions(left.version, right.version));
+    .sort((left, right) => compareOpenClawVersions(left.version, right.version));
 }
 const missingBaselineCount =
   rssBackfill || requestedVersions.length > 0

--- a/scripts/resolve-openclaw-discord-package.test.mjs
+++ b/scripts/resolve-openclaw-discord-package.test.mjs
@@ -268,3 +268,24 @@ test("queues Discord release rows missing RSS for backfill", async () => {
   assert.equal(outputs.versions, "2026.5.12");
   assert.deepEqual(JSON.parse(outputs.matrix).map((pkg) => pkg.version), ["2026.5.12"]);
 });
+
+test("uses numeric post releases as the stable Discord baseline", async () => {
+  const workspace = await makeWorkspace();
+  await writeJsonl(path.join(workspace, "data/channels/telegram.jsonl"), [
+    releaseRow("2026.7.1-1", "telegram"),
+  ]);
+  const binDir = await writeFakeNpm(workspace, ["2026.7.1-1", "2026.7.1-2"]);
+
+  const { stdout } = await execFileAsync(process.execPath, [RESOLVE_SCRIPT], {
+    cwd: workspace,
+    env: {
+      ...process.env,
+      GITHUB_OUTPUT: "",
+      PATH: `${binDir}${path.delimiter}${process.env.PATH}`,
+    },
+  });
+
+  const outputs = parseOutputs(stdout);
+  assert.equal(outputs.anchor, "2026.7.1-1");
+  assert.equal(outputs.versions, "2026.7.1-1 2026.7.1-2");
+});

--- a/scripts/resolve-openclaw-package.mjs
+++ b/scripts/resolve-openclaw-package.mjs
@@ -2,50 +2,16 @@ import { execFile } from "node:child_process";
 import fs from "node:fs/promises";
 import { promisify } from "node:util";
 import { resolveChannelRttChannel } from "./channel-rtt-config.mjs";
+import {
+  compareOpenClawVersions,
+  isStableOpenClawVersion,
+  parseOpenClawVersion,
+} from "./openclaw-version.mjs";
 import { readRows } from "./read-rows.mjs";
 import { channelReleaseSkipReason } from "./release-gap-reasons.mjs";
 
 const execFileAsync = promisify(execFile);
 const TELEGRAM_CHANNEL = resolveChannelRttChannel("telegram");
-const STABLE_VERSION_RE = /^([0-9]{4})\.([1-9][0-9]*)\.([1-9][0-9]*)$/u;
-const BETA_VERSION_RE = /^([0-9]{4})\.([1-9][0-9]*)\.([1-9][0-9]*)-beta\.([1-9][0-9]*)$/u;
-
-function parseVersion(version) {
-  const stableMatch = STABLE_VERSION_RE.exec(version);
-  if (stableMatch) {
-    return [...stableMatch.slice(1).map(Number), Number.MAX_SAFE_INTEGER];
-  }
-
-  const betaMatch = BETA_VERSION_RE.exec(version);
-  if (betaMatch) {
-    return betaMatch.slice(1).map(Number);
-  }
-
-  return undefined;
-}
-
-function parseStableRelease(version) {
-  const match = STABLE_VERSION_RE.exec(version);
-  if (!match) {
-    return undefined;
-  }
-  return match.slice(1).map(Number);
-}
-
-function compareVersions(left, right) {
-  const leftParts = parseVersion(left);
-  const rightParts = parseVersion(right);
-  if (!leftParts || !rightParts) {
-    throw new Error(`Cannot compare unsupported versions: ${left}, ${right}`);
-  }
-  for (let index = 0; index < leftParts.length; index += 1) {
-    const diff = leftParts[index] - rightParts[index];
-    if (diff !== 0) {
-      return diff;
-    }
-  }
-  return 0;
-}
 
 async function npmVersions() {
   const { stdout } = await execFileAsync("npm", ["view", "openclaw", "versions", "--json"], {
@@ -61,8 +27,8 @@ async function npmVersions() {
 function latestMeasuredStable(rows) {
   const latestStable = rows
     .map((row) => row.package.version)
-    .filter((version) => typeof version === "string" && parseStableRelease(version))
-    .sort(compareVersions)
+    .filter((version) => typeof version === "string" && isStableOpenClawVersion(version))
+    .sort(compareOpenClawVersions)
     .at(-1);
 
   if (!latestStable) {
@@ -78,7 +44,7 @@ function releaseRows(rows) {
       typeof row.package?.spec === "string" &&
       typeof row.package?.version === "string" &&
       row.package.spec === `openclaw@${row.package.version}` &&
-      parseVersion(row.package.version)
+      parseOpenClawVersion(row.package.version)
     ) {
       byVersion.set(row.package.version, row);
     }
@@ -128,7 +94,7 @@ function readRequestedVersionsEnv(name) {
     ),
   ];
   for (const version of versions) {
-    if (!parseVersion(version)) {
+    if (!parseOpenClawVersion(version)) {
       throw new Error(`${name} contains unsupported OpenClaw version: ${version}`);
     }
   }
@@ -163,25 +129,25 @@ if (requestedVersions.length > 0) {
   queue = requestedVersions
     .map((version) => ({ version, spec: `openclaw@${version}` }))
     .filter(isMeasurableRelease)
-    .sort((left, right) => compareVersions(left.version, right.version));
+    .sort((left, right) => compareOpenClawVersions(left.version, right.version));
 } else if (rssBackfill) {
   queue = releaseRows(rows)
     .filter((row) => row.resources?.maxRssKb?.max === undefined)
     .filter((row) => !rssBackfillSkipVersions.has(row.package.version))
     .map((row) => ({ version: row.package.version, spec: row.package.spec }))
-    .sort((left, right) => compareVersions(right.version, left.version))
+    .sort((left, right) => compareOpenClawVersions(right.version, left.version))
     .slice(0, rssBackfillLimit);
 } else {
   const measured = new Set(
     successfulReleaseRows(rows).map((row) => `${row.package.spec}\0${row.package.version}`),
   );
   queue = (await npmVersions())
-    .filter((version) => typeof version === "string" && parseVersion(version))
-    .filter((version) => compareVersions(version, anchor) > 0)
+    .filter((version) => typeof version === "string" && parseOpenClawVersion(version))
+    .filter((version) => compareOpenClawVersions(version, anchor) > 0)
     .map((version) => ({ version, spec: `openclaw@${version}` }))
     .filter(isMeasurableRelease)
     .filter((pkg) => !measured.has(`${pkg.spec}\0${pkg.version}`))
-    .sort((left, right) => compareVersions(left.version, right.version));
+    .sort((left, right) => compareOpenClawVersions(left.version, right.version));
 }
 
 await writeOutput({

--- a/scripts/resolve-openclaw-package.test.mjs
+++ b/scripts/resolve-openclaw-package.test.mjs
@@ -185,3 +185,30 @@ test("skips registered Telegram release gaps", async () => {
     /Skipping telegram openclaw@2026\.7\.1-beta\.4: published package omits @openclaw\/ai/u,
   );
 });
+
+test("discovers numeric post releases after a post-release stable anchor", async () => {
+  const workspace = await makeWorkspace();
+  await writeJsonl(path.join(workspace, "data/channels/telegram.jsonl"), [
+    releaseRow("2026.7.1"),
+    releaseRow("2026.7.1-1"),
+  ]);
+  const binDir = await writeFakeNpm(workspace, [
+    "2026.7.1-beta.4",
+    "2026.7.1",
+    "2026.7.1-1",
+    "2026.7.1-2",
+  ]);
+
+  const { stdout } = await execFileAsync(process.execPath, [RESOLVE_SCRIPT], {
+    cwd: workspace,
+    env: {
+      ...process.env,
+      GITHUB_OUTPUT: "",
+      PATH: `${binDir}${path.delimiter}${process.env.PATH}`,
+    },
+  });
+
+  const outputs = parseOutputs(stdout);
+  assert.equal(outputs.anchor, "2026.7.1-1");
+  assert.equal(outputs.versions, "2026.7.1-2");
+});

--- a/scripts/resolve-openclaw-surface-package.mjs
+++ b/scripts/resolve-openclaw-surface-package.mjs
@@ -1,48 +1,20 @@
 import { execFile } from "node:child_process";
 import fs from "node:fs/promises";
 import { promisify } from "node:util";
+import {
+  compareOpenClawVersions,
+  isOpenClawReleaseSpec,
+  parseOpenClawVersion,
+} from "./openclaw-version.mjs";
 import { readRows } from "./read-rows.mjs";
 import { listSurfaceRttSurfaces } from "./surface-rtt-config.mjs";
 import { readSurfaceRows } from "./surface-storage.mjs";
 
 const execFileAsync = promisify(execFile);
-const RELEASE_SPEC_RE =
-  /^openclaw@[0-9]{4}\.[1-9][0-9]*\.[1-9][0-9]*(?:-beta\.[1-9][0-9]*)?$/u;
-const STABLE_VERSION_RE = /^([0-9]{4})\.([1-9][0-9]*)\.([1-9][0-9]*)$/u;
-const BETA_VERSION_RE = /^([0-9]{4})\.([1-9][0-9]*)\.([1-9][0-9]*)-beta\.([1-9][0-9]*)$/u;
 const DEFAULT_SURFACES = ["control-ui"];
 const DEFAULT_VERSION_LIMIT = 4;
 const RELEASE_SURFACES = new Set(["control-ui"]);
 const RELEASE_SURFACE_MIN_VERSIONS = new Map([["control-ui", "2026.6.1-beta.3"]]);
-
-function parseVersion(version) {
-  const stableMatch = STABLE_VERSION_RE.exec(version);
-  if (stableMatch) {
-    return [...stableMatch.slice(1).map(Number), Number.MAX_SAFE_INTEGER];
-  }
-
-  const betaMatch = BETA_VERSION_RE.exec(version);
-  if (betaMatch) {
-    return betaMatch.slice(1).map(Number);
-  }
-
-  return undefined;
-}
-
-function compareVersions(left, right) {
-  const leftParts = parseVersion(left);
-  const rightParts = parseVersion(right);
-  if (!leftParts || !rightParts) {
-    throw new Error(`Cannot compare unsupported versions: ${left}, ${right}`);
-  }
-  for (let index = 0; index < leftParts.length; index += 1) {
-    const diff = leftParts[index] - rightParts[index];
-    if (diff !== 0) {
-      return diff;
-    }
-  }
-  return 0;
-}
 
 function readList(value) {
   if (!value) {
@@ -72,7 +44,7 @@ function readPositiveIntegerEnv(name, fallback) {
 async function npmVersions() {
   const fixture = process.env.INPUT_AVAILABLE_VERSIONS;
   if (fixture) {
-    return new Set(readList(fixture).filter((version) => parseVersion(version)));
+    return new Set(readList(fixture).filter((version) => parseOpenClawVersion(version)));
   }
   const { stdout } = await execFileAsync("npm", ["view", "openclaw", "versions", "--json"], {
     timeout: 30_000,
@@ -81,16 +53,18 @@ async function npmVersions() {
   if (!Array.isArray(parsed)) {
     throw new Error("npm view openclaw versions --json must return an array.");
   }
-  return new Set(parsed.filter((version) => typeof version === "string" && parseVersion(version)));
+  return new Set(
+    parsed.filter((version) => typeof version === "string" && parseOpenClawVersion(version)),
+  );
 }
 
 function releaseRows(rows) {
   return rows.filter(
     (row) =>
       typeof row.package?.spec === "string" &&
-      RELEASE_SPEC_RE.test(row.package.spec) &&
+      isOpenClawReleaseSpec(row.package.spec) &&
       typeof row.package?.version === "string" &&
-      parseVersion(row.package.version),
+      parseOpenClawVersion(row.package.version),
   );
 }
 
@@ -146,8 +120,8 @@ for (const surfaceId of surfaceIds) {
   const measuredVersions = surfaceRows
     .filter((row) => row.run?.status === "pass")
     .map((row) => row.package.version)
-    .filter((version) => parseVersion(version));
-  const latestMeasured = measuredVersions.sort(compareVersions).at(-1);
+    .filter((version) => parseOpenClawVersion(version));
+  const latestMeasured = measuredVersions.sort(compareOpenClawVersions).at(-1);
   const minimumVersion = RELEASE_SURFACE_MIN_VERSIONS.get(surfaceId);
   const versions =
     explicitVersions.length > 0
@@ -157,11 +131,12 @@ for (const surfaceId of surfaceIds) {
             (version) =>
               baselineVersions.has(version) ||
               !latestMeasured ||
-              compareVersions(version, latestMeasured) > 0,
+              compareOpenClawVersions(version, latestMeasured) > 0,
           )
           .filter(
             (version) =>
-              (!minimumVersion || compareVersions(version, minimumVersion) >= 0) &&
+              (!minimumVersion ||
+                compareOpenClawVersions(version, minimumVersion) >= 0) &&
               !measured.has(`${surfaceId}\0openclaw@${version}\0${version}`),
           )
           .sort((left, right) => {
@@ -171,12 +146,13 @@ for (const surfaceId of surfaceIds) {
             const rightAttempted = attempted.has(
               `${surfaceId}\0openclaw@${right}\0${right}`,
             );
-            return Number(leftAttempted) - Number(rightAttempted) || compareVersions(left, right);
+            const attemptDiff = Number(leftAttempted) - Number(rightAttempted);
+            return attemptDiff || compareOpenClawVersions(left, right);
           })
           .slice(0, versionLimit);
 
   for (const version of versions) {
-    if (!parseVersion(version)) {
+    if (!parseOpenClawVersion(version)) {
       throw new Error(`Unsupported version: ${version}`);
     }
     if (!availableVersions.has(version)) {
@@ -211,7 +187,7 @@ queue.sort((left, right) => {
       return attemptDiff;
     }
   }
-  const versionDiff = compareVersions(left.version, right.version);
+  const versionDiff = compareOpenClawVersions(left.version, right.version);
   if (versionDiff !== 0) {
     return versionDiff;
   }

--- a/scripts/resolve-openclaw-surface-package.test.mjs
+++ b/scripts/resolve-openclaw-surface-package.test.mjs
@@ -203,3 +203,23 @@ test("rejects release surfaces without a native release measurer", async () => {
     },
   }), /Surface rpc is not supported by release surface RTT/u);
 });
+
+test("queues explicit numeric post releases for release surfaces", async () => {
+  const workspace = await makeWorkspace();
+
+  const { stdout } = await execFileAsync(process.execPath, [RESOLVE_SCRIPT], {
+    cwd: workspace,
+    env: {
+      ...process.env,
+      GITHUB_OUTPUT: "",
+      INPUT_AVAILABLE_VERSIONS: "2026.7.1-2",
+      INPUT_SURFACES: "control-ui",
+      INPUT_VERSIONS: "2026.7.1-2",
+    },
+  });
+
+  const outputs = parseOutputs(stdout);
+  assert.deepEqual(JSON.parse(outputs.matrix).map((entry) => entry.version), [
+    "2026.7.1-2",
+  ]);
+});

--- a/scripts/update-readme.mjs
+++ b/scripts/update-readme.mjs
@@ -2,6 +2,10 @@ import fs from "node:fs/promises";
 import { listChannelRttChannels } from "./channel-rtt-config.mjs";
 import { readChannelRttRows } from "./read-channel-rtt-rows.mjs";
 import { readDiscordRttRows } from "./read-discord-rtt-rows.mjs";
+import {
+  compareOpenClawVersions,
+  isOpenClawReleaseSpec,
+} from "./openclaw-version.mjs";
 import { readRows } from "./read-rows.mjs";
 import { readSurfaceRttRows } from "./read-surface-rtt-rows.mjs";
 import {
@@ -43,14 +47,10 @@ const SURFACE_DASHBOARD_ORDER = new Map([
 const CHANNEL_CONFIG_BY_LABEL = new Map(
   listChannelRttChannels().map((channel) => [channel.label, channel]),
 );
-const RELEASE_SPEC_RE =
-  /^openclaw@[0-9]{4}\.[1-9][0-9]*\.[1-9][0-9]*(?:-beta\.[1-9][0-9]*)?$/u;
 const RELEASE_COVERAGE_MIN_VERSION = "2026.4.24";
 const SURFACE_RELEASE_COVERAGE_MIN_VERSIONS = new Map([
   ["Control UI", "2026.6.1-beta.3"],
 ]);
-const STABLE_VERSION_RE = /^([0-9]{4})\.([1-9][0-9]*)\.([1-9][0-9]*)$/u;
-const BETA_VERSION_RE = /^([0-9]{4})\.([1-9][0-9]*)\.([1-9][0-9]*)-beta\.([1-9][0-9]*)$/u;
 const UPDATE_LATEST_MAIN_ONLY = process.argv.includes("--latest-main-only");
 
 function formatMs(value) {
@@ -69,35 +69,6 @@ function formatVersion(value) {
 
 function escapeMarkdownTableCell(value) {
   return value.replaceAll("|", "\\|");
-}
-
-function parseVersion(version) {
-  const stableMatch = STABLE_VERSION_RE.exec(version);
-  if (stableMatch) {
-    return [...stableMatch.slice(1).map(Number), Number.MAX_SAFE_INTEGER];
-  }
-
-  const betaMatch = BETA_VERSION_RE.exec(version);
-  if (betaMatch) {
-    return betaMatch.slice(1).map(Number);
-  }
-
-  return undefined;
-}
-
-function compareVersions(left, right) {
-  const leftParts = parseVersion(left);
-  const rightParts = parseVersion(right);
-  if (!leftParts || !rightParts) {
-    throw new Error(`Cannot compare unsupported versions: ${left}, ${right}`);
-  }
-  for (let index = 0; index < leftParts.length; index += 1) {
-    const diff = leftParts[index] - rightParts[index];
-    if (diff !== 0) {
-      return diff;
-    }
-  }
-  return 0;
 }
 
 function latestMainRow({ label, row, rssP50 = "n/a", rssP95 = "n/a", status = "missing" }) {
@@ -369,10 +340,10 @@ function surfaceLatestTableFor(surfaceRows) {
   ].join("\n");
 }
 
-function releaseRows(rows, specRe = RELEASE_SPEC_RE) {
+function releaseRows(rows) {
   const byVersion = new Map();
   for (const row of rows) {
-    if (!specRe.test(row.package.spec)) {
+    if (!isOpenClawReleaseSpec(row.package.spec)) {
       continue;
     }
     const existing = byVersion.get(row.package.version) ?? [];
@@ -382,15 +353,19 @@ function releaseRows(rows, specRe = RELEASE_SPEC_RE) {
   return [...byVersion.values()]
     .map(latestReleaseSummaryRow)
     .filter(Boolean)
-    .sort((left, right) => compareVersions(right.package.version, left.package.version));
+    .sort((left, right) =>
+      compareOpenClawVersions(right.package.version, left.package.version),
+    );
 }
 
 function releaseVersionAxis(...rowGroups) {
   return [
     ...new Set(rowGroups.flatMap((rows) => releaseRows(rows).map((row) => row.package.version))),
   ]
-    .filter((version) => compareVersions(version, RELEASE_COVERAGE_MIN_VERSION) >= 0)
-    .sort((left, right) => compareVersions(right, left));
+    .filter(
+      (version) => compareOpenClawVersions(version, RELEASE_COVERAGE_MIN_VERSION) >= 0,
+    )
+    .sort((left, right) => compareOpenClawVersions(right, left));
 }
 
 function releaseTableVersions(tableRows, versionAxis) {
@@ -401,9 +376,11 @@ function releaseTableVersions(tableRows, versionAxis) {
   return [
     ...new Set([
       ...versionAxis,
-      ...ownVersions.filter((version) => compareVersions(version, RELEASE_COVERAGE_MIN_VERSION) < 0),
+      ...ownVersions.filter(
+        (version) => compareOpenClawVersions(version, RELEASE_COVERAGE_MIN_VERSION) < 0,
+      ),
     ]),
-  ].sort((left, right) => compareVersions(right, left));
+  ].sort((left, right) => compareOpenClawVersions(right, left));
 }
 
 function releaseSkipReason(label, version) {
@@ -415,7 +392,8 @@ function releaseSkipReason(label, version) {
     return channelReleaseSkipReason(channel, version);
   }
   const surfaceMinVersion = SURFACE_RELEASE_COVERAGE_MIN_VERSIONS.get(label);
-  return surfaceMinVersion && compareVersions(version, surfaceMinVersion) < 0
+  return surfaceMinVersion &&
+    compareOpenClawVersions(version, surfaceMinVersion) < 0
     ? `surface release coverage starts at ${surfaceMinVersion}`
     : undefined;
 }
@@ -581,8 +559,10 @@ function releaseCoverageTableFor(telegramRows, discordRows, channelRows, surface
   const versions = [
     ...new Set([...rowsByTarget.values()].flatMap((rowsByVersion) => [...rowsByVersion.keys()])),
   ]
-    .filter((version) => compareVersions(version, RELEASE_COVERAGE_MIN_VERSION) >= 0)
-    .sort((left, right) => compareVersions(right, left));
+    .filter(
+      (version) => compareOpenClawVersions(version, RELEASE_COVERAGE_MIN_VERSION) >= 0,
+    )
+    .sort((left, right) => compareOpenClawVersions(right, left));
   if (versions.length === 0) {
     return [
       RELEASE_COVERAGE_START,
@@ -623,8 +603,10 @@ function surfaceReleaseCoverageTableFor(surfaceRows) {
   const versions = [
     ...new Set([...rowsBySurface.values()].flatMap((rowsByVersion) => [...rowsByVersion.keys()])),
   ]
-    .filter((version) => compareVersions(version, RELEASE_COVERAGE_MIN_VERSION) >= 0)
-    .sort((left, right) => compareVersions(right, left));
+    .filter(
+      (version) => compareOpenClawVersions(version, RELEASE_COVERAGE_MIN_VERSION) >= 0,
+    )
+    .sort((left, right) => compareOpenClawVersions(right, left));
   if (versions.length === 0) {
     return [
       SURFACE_RELEASE_COVERAGE_START,

--- a/scripts/update-readme.test.mjs
+++ b/scripts/update-readme.test.mjs
@@ -650,3 +650,44 @@ test("keeps prior release RTT visible when a newer import has only RSS", async (
     /\| `2026\.5\.16-beta\.6` \| `7,800ms` \| `7,900ms` \| `768MB` \| `780MB` \|/u,
   );
 });
+
+test("renders numeric post releases after stable in descending release order", async () => {
+  const workspace = await makeWorkspace();
+  await writeReadme(workspace);
+  const versions = [
+    "2026.7.1-beta.4",
+    "2026.7.1",
+    "2026.7.1-1",
+    "2026.7.1-2",
+  ];
+  await writeJsonl(
+    path.join(workspace, "data/channels/telegram.jsonl"),
+    versions.map((version, index) =>
+      rttRow({
+        package: { spec: `openclaw@${version}`, version },
+        run: {
+          id: `telegram-${version}`,
+          startedAt: `2026-07-01T00:0${index}:00.000Z`,
+          status: "pass",
+        },
+        rtt: { warmSamples: [1000 + index], p50Ms: 1000 + index, p95Ms: 2000 + index },
+      }),
+    ),
+  );
+
+  await execFileAsync(process.execPath, [UPDATE_README_SCRIPT], { cwd: workspace });
+
+  const readme = await fs.readFile(path.join(workspace, "README.md"), "utf8");
+  const telegramSection = readme.slice(
+    readme.indexOf("<!-- release-sweep:start -->"),
+    readme.indexOf("<!-- release-sweep:end -->"),
+  );
+  const positions = versions.map((version) => telegramSection.indexOf(`\`${version}\``));
+  assert.ok(positions.every((position) => position >= 0));
+  assert.deepEqual([...positions].sort((left, right) => left - right), [
+    positions[3],
+    positions[2],
+    positions[1],
+    positions[0],
+  ]);
+});


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where release RTT workflows rejected published OpenClaw numeric post-release packages such as `2026.7.1-2` before QA could run.

Live failure: https://github.com/openclaw/openclaw-rtt/actions/runs/32757078290

## Why This Change Was Made

Release selection and README hydration now share one strict OpenClaw version contract for beta, stable, and numeric post-release packages, ordered `beta < stable < -1 < -2`. Stable baselines include numeric post releases. The copied upstream release QA compatibility helper keeps an equivalent self-contained parser so historical package config projection remains correct.

## User Impact

Operators can include published numeric post-release packages in release RTT matrices without special-case inputs or parser failures. Unsupported suffixes remain rejected.

## Evidence

- Upstream historical package proof: https://github.com/openclaw/openclaw/actions/runs/32755849768
  - `openclaw@2026.7.1-2`
  - `telegram-reply-chain-exact-marker`
  - 20/21 checks, p50 1049ms, p95 2053ms
- `npm test`: 75/75 passing
- `npm run check`: syntax, 4,069 stored RTT rows, README hydration consistency
- `actionlint`: clean
- `git diff --check`: clean
- privacy scan: clean
- TruffleHog 3.95.9: 0 verified or unverified secrets
- fresh autoreview: clean, no actionable findings, 0.96 confidence
