### PR TITLE
ci: lease Telegram RTT userbots from Convex

### DIFF
--- a/.github/workflows/main-rtt.yml
+++ b/.github/workflows/main-rtt.yml
@@ -117,9 +117,10 @@ jobs:
         id: rtt
         working-directory: openclaw
         env:
-          OPENCLAW_QA_TELEGRAM_GROUP_ID: ${{ secrets.OPENCLAW_QA_TELEGRAM_GROUP_ID }}
-          OPENCLAW_QA_TELEGRAM_DRIVER_BOT_TOKEN: ${{ secrets.OPENCLAW_QA_TELEGRAM_DRIVER_BOT_TOKEN }}
-          OPENCLAW_QA_TELEGRAM_SUT_BOT_TOKEN: ${{ secrets.OPENCLAW_QA_TELEGRAM_SUT_BOT_TOKEN }}
+          OPENCLAW_QA_CREDENTIAL_SOURCE: convex
+          OPENCLAW_QA_CREDENTIAL_ROLE: ci
+          OPENCLAW_QA_CONVEX_SITE_URL: ${{ secrets.OPENCLAW_QA_CONVEX_SITE_URL }}
+          OPENCLAW_QA_CONVEX_SECRET_CI: ${{ secrets.OPENCLAW_QA_CONVEX_SECRET_CI }}
           INPUT_SAMPLES: ${{ github.event_name == 'workflow_dispatch' && inputs.samples || '20' }}
         shell: bash
         run: |

--- a/.github/workflows/stable-release-rtt.yml
+++ b/.github/workflows/stable-release-rtt.yml
@@ -134,9 +134,10 @@ jobs:
         working-directory: openclaw
         env:
           OPENCLAW_ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS: "1"
-          OPENCLAW_QA_TELEGRAM_GROUP_ID: ${{ secrets.OPENCLAW_QA_TELEGRAM_GROUP_ID }}
-          OPENCLAW_QA_TELEGRAM_DRIVER_BOT_TOKEN: ${{ secrets.OPENCLAW_QA_TELEGRAM_DRIVER_BOT_TOKEN }}
-          OPENCLAW_QA_TELEGRAM_SUT_BOT_TOKEN: ${{ secrets.OPENCLAW_QA_TELEGRAM_SUT_BOT_TOKEN }}
+          OPENCLAW_QA_CREDENTIAL_SOURCE: convex
+          OPENCLAW_QA_CREDENTIAL_ROLE: ci
+          OPENCLAW_QA_CONVEX_SITE_URL: ${{ secrets.OPENCLAW_QA_CONVEX_SITE_URL }}
+          OPENCLAW_QA_CONVEX_SECRET_CI: ${{ secrets.OPENCLAW_QA_CONVEX_SECRET_CI }}
         shell: bash
         run: |
           set -euo pipefail
@@ -203,9 +204,10 @@ jobs:
         working-directory: openclaw
         env:
           OPENCLAW_ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS: "1"
-          OPENCLAW_QA_TELEGRAM_GROUP_ID: ${{ secrets.OPENCLAW_QA_TELEGRAM_GROUP_ID }}
-          OPENCLAW_QA_TELEGRAM_DRIVER_BOT_TOKEN: ${{ secrets.OPENCLAW_QA_TELEGRAM_DRIVER_BOT_TOKEN }}
-          OPENCLAW_QA_TELEGRAM_SUT_BOT_TOKEN: ${{ secrets.OPENCLAW_QA_TELEGRAM_SUT_BOT_TOKEN }}
+          OPENCLAW_QA_CREDENTIAL_SOURCE: convex
+          OPENCLAW_QA_CREDENTIAL_ROLE: ci
+          OPENCLAW_QA_CONVEX_SITE_URL: ${{ secrets.OPENCLAW_QA_CONVEX_SITE_URL }}
+          OPENCLAW_QA_CONVEX_SECRET_CI: ${{ secrets.OPENCLAW_QA_CONVEX_SECRET_CI }}
         shell: bash
         run: |
           set -euo pipefail

--- a/scripts/telegram-rtt-workflow-contract.test.mjs
+++ b/scripts/telegram-rtt-workflow-contract.test.mjs
@@ -19,6 +19,8 @@ const RETIRED_HELPER_PATHS = [
 const RTT_SELECTION =
   "OPENCLAW_NPM_TELEGRAM_RTT_CHECKS=telegram-reply-chain-exact-marker";
 const IMPORT_SCENARIO = "--scenario telegram-reply-chain-exact-marker";
+const CONVEX_SOURCE = "OPENCLAW_QA_CREDENTIAL_SOURCE: convex";
+const CONVEX_ROLE = "OPENCLAW_QA_CREDENTIAL_ROLE: ci";
 
 function countOccurrences(contents, value) {
   return contents.split(value).length - 1;
@@ -32,10 +34,22 @@ test("Telegram RTT workflows use the upstream harness contract", async () => {
     })),
   );
 
-  assert.equal(countOccurrences(workflows[0].contents, RTT_SELECTION), 1);
-  assert.equal(countOccurrences(workflows[1].contents, RTT_SELECTION), 2);
+  const expectedRuns = [1, 2];
+  assert.equal(countOccurrences(workflows[0].contents, RTT_SELECTION), expectedRuns[0]);
+  assert.equal(countOccurrences(workflows[1].contents, RTT_SELECTION), expectedRuns[1]);
 
-  for (const { contents, relativePath } of workflows) {
+  for (const [index, { contents, relativePath }] of workflows.entries()) {
+    assert.equal(countOccurrences(contents, CONVEX_SOURCE), expectedRuns[index]);
+    assert.equal(countOccurrences(contents, CONVEX_ROLE), expectedRuns[index]);
+    assert.equal(
+      countOccurrences(contents, "OPENCLAW_QA_CONVEX_SITE_URL: ${{ secrets.OPENCLAW_QA_CONVEX_SITE_URL }}"),
+      expectedRuns[index],
+    );
+    assert.equal(
+      countOccurrences(contents, "OPENCLAW_QA_CONVEX_SECRET_CI: ${{ secrets.OPENCLAW_QA_CONVEX_SECRET_CI }}"),
+      expectedRuns[index],
+    );
+    assert.doesNotMatch(contents, /OPENCLAW_QA_TELEGRAM_(?:GROUP_ID|DRIVER_BOT_TOKEN|SUT_BOT_TOKEN)/u);
     assert.equal(
       countOccurrences(contents, IMPORT_SCENARIO),
       1,


### PR DESCRIPTION
## Summary

- Replace three static Telegram secrets with the shared Convex broker pair.
- Select the `ci` lease role for main, release, and RSS backfill runs.
- Keep the existing RTT scenario, samples, package compatibility, evidence import, and data format unchanged.
- Add workflow contract coverage that rejects the retired static secret names.

## Validation

- `npm test`: 75 tests pass.
- `npm run check`: 416 Telegram RTT rows, 611 Discord RTT rows, 2309 channel RTT rows, and 831 surface RTT rows validate.
- `git diff --check` passes.

## Dependency

Merge after openclaw/openclaw#133030, which teaches the upstream Telegram QA adapter to consume `telegram-test-userbot` leases.