### PR TITLE
fix(ci): align Telegram RTT pnpm version

### DIFF
--- a/.github/workflows/main-rtt.yml
+++ b/.github/workflows/main-rtt.yml
@@ -21,7 +21,7 @@ concurrency:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   NODE_VERSION: "26.x"
-  PNPM_VERSION: "11.2.2"
+  PNPM_VERSION: "12.1.0"
 
 jobs:
   measure:

--- a/.github/workflows/stable-release-rtt.yml
+++ b/.github/workflows/stable-release-rtt.yml
@@ -39,7 +39,7 @@ concurrency:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   NODE_VERSION: "26.x"
-  PNPM_VERSION: "11.2.2"
+  PNPM_VERSION: "12.1.0"
 
 jobs:
   measure:

--- a/scripts/telegram-rtt-workflow-contract.test.mjs
+++ b/scripts/telegram-rtt-workflow-contract.test.mjs
@@ -21,6 +21,7 @@ const RTT_SELECTION =
 const IMPORT_SCENARIO = "--scenario telegram-reply-chain-exact-marker";
 const CONVEX_SOURCE = "OPENCLAW_QA_CREDENTIAL_SOURCE: convex";
 const CONVEX_ROLE = "OPENCLAW_QA_CREDENTIAL_ROLE: ci";
+const PNPM_VERSION = 'PNPM_VERSION: "12.1.0"';
 
 function countOccurrences(contents, value) {
   return contents.split(value).length - 1;
@@ -39,6 +40,7 @@ test("Telegram RTT workflows use the upstream harness contract", async () => {
   assert.equal(countOccurrences(workflows[1].contents, RTT_SELECTION), expectedRuns[1]);
 
   for (const [index, { contents, relativePath }] of workflows.entries()) {
+    assert.equal(countOccurrences(contents, PNPM_VERSION), 1);
     assert.equal(countOccurrences(contents, CONVEX_SOURCE), expectedRuns[index]);
     assert.equal(countOccurrences(contents, CONVEX_ROLE), expectedRuns[index]);
     assert.equal(


### PR DESCRIPTION
## Summary

- Use pnpm 12.1.0 in main and release Telegram RTT workflows.
- Match the checked-out OpenClaw `packageManager` contract.
- Prevent Corepack from selecting an unprepared pnpm binary and sending an empty cache path to `actions/cache`.

## Proof

Both merged workflows failed before build with `Cannot find module .../corepack/v1/pnpm/12.1.0/bin/pnpm.cjs`, followed by `Input required and not supplied: path`.

- `npm test`: 75 passing.
- `npm run check`: all stored RTT data validates.
- Workflow contract tests pin pnpm 12.1.0 in both files.