### PR TITLE
fix(ci): install pnpm without Corepack

### DIFF
--- a/.github/workflows/main-rtt.yml
+++ b/.github/workflows/main-rtt.yml
@@ -55,11 +55,9 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Setup pnpm
-        shell: bash
-        run: |
-          set -euo pipefail
-          corepack enable
-          corepack prepare "pnpm@${PNPM_VERSION}" --activate
+        uses: pnpm/action-setup@v6.0.10
+        with:
+          version: ${{ env.PNPM_VERSION }}
 
       - name: Locate pnpm store
         id: pnpm-store

--- a/.github/workflows/stable-release-rtt.yml
+++ b/.github/workflows/stable-release-rtt.yml
@@ -89,11 +89,9 @@ jobs:
 
       - name: Setup pnpm
         if: steps.release.outputs.should_run == 'true'
-        shell: bash
-        run: |
-          set -euo pipefail
-          corepack enable
-          corepack prepare "pnpm@${PNPM_VERSION}" --activate
+        uses: pnpm/action-setup@v6.0.10
+        with:
+          version: ${{ env.PNPM_VERSION }}
 
       - name: Locate pnpm store
         if: steps.release.outputs.should_run == 'true'

--- a/scripts/telegram-rtt-workflow-contract.test.mjs
+++ b/scripts/telegram-rtt-workflow-contract.test.mjs
@@ -41,6 +41,7 @@ test("Telegram RTT workflows use the upstream harness contract", async () => {
 
   for (const [index, { contents, relativePath }] of workflows.entries()) {
     assert.equal(countOccurrences(contents, PNPM_VERSION), 1);
+    assert.equal(countOccurrences(contents, "uses: pnpm/action-setup@v6.0.10"), 1);
     assert.equal(countOccurrences(contents, CONVEX_SOURCE), expectedRuns[index]);
     assert.equal(countOccurrences(contents, CONVEX_ROLE), expectedRuns[index]);
     assert.equal(


### PR DESCRIPTION
## Summary

- Install pnpm 12.1.0 with the pinned `pnpm/action-setup` action.
- Avoid the broken Blacksmith Corepack cache path.
- Keep the existing pnpm store cache and workflow behavior.

## Proof

Both Telegram RTT workflows prepared pnpm 12.1.0, then Corepack executed a missing cached `pnpm.cjs`. The store-path output became empty and `actions/cache` failed with `Input required and not supplied: path`.

`npm test`: 75 passing.