### PR TITLE
fix(ci): use pnpm 12 install flags

### DIFF
--- a/.github/workflows/main-rtt.yml
+++ b/.github/workflows/main-rtt.yml
@@ -82,7 +82,7 @@ jobs:
         run: |
           set -euo pipefail
           echo "::group::pnpm install"
-          time pnpm install --frozen-lockfile --prefer-offline --ignore-scripts=false --config.engine-strict=false --config.enable-pre-post-scripts=true --config.side-effects-cache=true
+          time pnpm install --frozen-lockfile --prefer-offline --config.engine-strict=false --config.enable-pre-post-scripts=true --config.side-effects-cache=true
           echo "::endgroup::"
           echo "::group::pnpm build"
           time pnpm build

--- a/.github/workflows/stable-release-rtt.yml
+++ b/.github/workflows/stable-release-rtt.yml
@@ -117,7 +117,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          time pnpm install --frozen-lockfile --prefer-offline --ignore-scripts=false --config.engine-strict=false --config.enable-pre-post-scripts=true --config.side-effects-cache=true
+          time pnpm install --frozen-lockfile --prefer-offline --config.engine-strict=false --config.enable-pre-post-scripts=true --config.side-effects-cache=true
 
       - name: Build OpenClaw QA harness
         if: steps.release.outputs.should_run == 'true'

--- a/scripts/telegram-rtt-workflow-contract.test.mjs
+++ b/scripts/telegram-rtt-workflow-contract.test.mjs
@@ -42,6 +42,7 @@ test("Telegram RTT workflows use the upstream harness contract", async () => {
   for (const [index, { contents, relativePath }] of workflows.entries()) {
     assert.equal(countOccurrences(contents, PNPM_VERSION), 1);
     assert.equal(countOccurrences(contents, "uses: pnpm/action-setup@v6.0.10"), 1);
+    assert.doesNotMatch(contents, /--ignore-scripts=false/u);
     assert.equal(countOccurrences(contents, CONVEX_SOURCE), expectedRuns[index]);
     assert.equal(countOccurrences(contents, CONVEX_ROLE), expectedRuns[index]);
     assert.equal(


### PR DESCRIPTION
## Summary

- Remove the obsolete `--ignore-scripts=false` value form from both Telegram RTT installs.
- Keep lifecycle scripts enabled through pnpm 12 defaults.
- Add workflow contract coverage.

## Proof

Both workflows now reach pnpm 12, which exits 2 on `unexpected value false for --ignore-scripts`.

`npm test`: 75 passing.