### PR TITLE
fix(ci): keep Telegram RTT transport-focused

### DIFF
--- a/.github/workflows/main-rtt.yml
+++ b/.github/workflows/main-rtt.yml
@@ -119,6 +119,7 @@ jobs:
           OPENCLAW_QA_CREDENTIAL_ROLE: ci
           OPENCLAW_QA_CONVEX_SITE_URL: ${{ secrets.OPENCLAW_QA_CONVEX_SITE_URL }}
           OPENCLAW_QA_CONVEX_SECRET_CI: ${{ secrets.OPENCLAW_QA_CONVEX_SECRET_CI }}
+          OPENCLAW_NPM_TELEGRAM_SKIP_HOTPATH: "1"
           INPUT_SAMPLES: ${{ github.event_name == 'workflow_dispatch' && inputs.samples || '20' }}
         shell: bash
         run: |

--- a/.github/workflows/stable-release-rtt.yml
+++ b/.github/workflows/stable-release-rtt.yml
@@ -136,6 +136,7 @@ jobs:
           OPENCLAW_QA_CREDENTIAL_ROLE: ci
           OPENCLAW_QA_CONVEX_SITE_URL: ${{ secrets.OPENCLAW_QA_CONVEX_SITE_URL }}
           OPENCLAW_QA_CONVEX_SECRET_CI: ${{ secrets.OPENCLAW_QA_CONVEX_SECRET_CI }}
+          OPENCLAW_NPM_TELEGRAM_SKIP_HOTPATH: "1"
         shell: bash
         run: |
           set -euo pipefail
@@ -206,6 +207,7 @@ jobs:
           OPENCLAW_QA_CREDENTIAL_ROLE: ci
           OPENCLAW_QA_CONVEX_SITE_URL: ${{ secrets.OPENCLAW_QA_CONVEX_SITE_URL }}
           OPENCLAW_QA_CONVEX_SECRET_CI: ${{ secrets.OPENCLAW_QA_CONVEX_SECRET_CI }}
+          OPENCLAW_NPM_TELEGRAM_SKIP_HOTPATH: "1"
         shell: bash
         run: |
           set -euo pipefail

--- a/scripts/telegram-rtt-workflow-contract.test.mjs
+++ b/scripts/telegram-rtt-workflow-contract.test.mjs
@@ -46,6 +46,10 @@ test("Telegram RTT workflows use the upstream harness contract", async () => {
     assert.equal(countOccurrences(contents, CONVEX_SOURCE), expectedRuns[index]);
     assert.equal(countOccurrences(contents, CONVEX_ROLE), expectedRuns[index]);
     assert.equal(
+      countOccurrences(contents, 'OPENCLAW_NPM_TELEGRAM_SKIP_HOTPATH: "1"'),
+      expectedRuns[index],
+    );
+    assert.equal(
       countOccurrences(contents, "OPENCLAW_QA_CONVEX_SITE_URL: ${{ secrets.OPENCLAW_QA_CONVEX_SITE_URL }}"),
       expectedRuns[index],
     );


### PR DESCRIPTION
## Summary

- Skip the unrelated installed-package onboarding recovery probe in Telegram RTT workflows.
- Keep the installed package as the SUT and retain all package compatibility projections.
- Let Package Acceptance own onboarding recovery coverage.

## Proof

Release RTT reaches the package runner, then the onboarding probe exits before credential leasing and produces no `qa-evidence.json`.

`npm test`: 75 passing.
`npm run check`: all RTT data validates.