### PR TITLE
fix(ci): refresh pnpm and repair RTT workflow setup

### DIFF
--- a/.github/workflows/crabbox-hydrate.yml
+++ b/.github/workflows/crabbox-hydrate.yml
@@ -31,7 +31,7 @@ permissions:
 
 env:
   NODE_VERSION: "24"
-  PNPM_VERSION: "11.1.2"
+  PNPM_VERSION: "11.24.0"
 
 jobs:
   hydrate:

--- a/.github/workflows/main-channel-rtt.yml
+++ b/.github/workflows/main-channel-rtt.yml
@@ -28,7 +28,7 @@ permissions:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   NODE_VERSION: "26.x"
-  PNPM_VERSION: "11.2.2"
+  PNPM_VERSION: "12.1.0"
   CHANNEL_RTT_PR_SAMPLES: "3"
   CHANNEL_RTT_MAX_ATTEMPTS: "3"
   CHANNEL_RTT_RETRY_BASE_SECONDS: "15"
@@ -120,11 +120,9 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Setup pnpm
-        shell: bash
-        run: |
-          set -euo pipefail
-          corepack enable
-          corepack prepare "pnpm@${PNPM_VERSION}" --activate
+        uses: pnpm/action-setup@v6.0.10
+        with:
+          version: ${{ env.PNPM_VERSION }}
 
       - name: Locate pnpm store
         id: pnpm-store
@@ -132,7 +130,9 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          echo "path=$(pnpm store path --silent)" >>"$GITHUB_OUTPUT"
+          store_path="$(pnpm store path --silent)"
+          test -n "$store_path"
+          printf 'path=%s\n' "$store_path" >>"$GITHUB_OUTPUT"
 
       - name: Restore pnpm store
         uses: actions/cache@v6
@@ -147,7 +147,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          time pnpm install --frozen-lockfile --prefer-offline --ignore-scripts=false --config.engine-strict=false --config.enable-pre-post-scripts=true --config.side-effects-cache=true
+          time pnpm install --frozen-lockfile --prefer-offline --config.engine-strict=false --config.enable-pre-post-scripts=true --config.side-effects-cache=true
 
       - name: Resolve OpenClaw ref
         id: openclaw_ref

--- a/.github/workflows/main-discord-rtt.yml
+++ b/.github/workflows/main-discord-rtt.yml
@@ -21,7 +21,7 @@ concurrency:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   NODE_VERSION: "26.x"
-  PNPM_VERSION: "11.2.2"
+  PNPM_VERSION: "12.1.0"
 
 jobs:
   measure:
@@ -51,11 +51,9 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Setup pnpm
-        shell: bash
-        run: |
-          set -euo pipefail
-          corepack enable
-          corepack prepare "pnpm@${PNPM_VERSION}" --activate
+        uses: pnpm/action-setup@v6.0.10
+        with:
+          version: ${{ env.PNPM_VERSION }}
 
       - name: Locate pnpm store
         id: pnpm-store
@@ -63,7 +61,9 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          echo "path=$(pnpm store path --silent)" >>"$GITHUB_OUTPUT"
+          store_path="$(pnpm store path --silent)"
+          test -n "$store_path"
+          printf 'path=%s\n' "$store_path" >>"$GITHUB_OUTPUT"
 
       - name: Restore pnpm store
         uses: actions/cache@v6
@@ -78,7 +78,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          time pnpm install --frozen-lockfile --prefer-offline --ignore-scripts=false --config.engine-strict=false --config.enable-pre-post-scripts=true --config.side-effects-cache=true
+          time pnpm install --frozen-lockfile --prefer-offline --config.engine-strict=false --config.enable-pre-post-scripts=true --config.side-effects-cache=true
 
       - name: Resolve OpenClaw ref
         id: openclaw_ref

--- a/.github/workflows/main-rtt.yml
+++ b/.github/workflows/main-rtt.yml
@@ -65,7 +65,9 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          echo "path=$(pnpm store path --silent)" >>"$GITHUB_OUTPUT"
+          store_path="$(pnpm store path --silent)"
+          test -n "$store_path"
+          printf 'path=%s\n' "$store_path" >>"$GITHUB_OUTPUT"
 
       - name: Restore pnpm store
         uses: actions/cache@v6

--- a/.github/workflows/main-surface-rtt.yml
+++ b/.github/workflows/main-surface-rtt.yml
@@ -30,7 +30,7 @@ permissions:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   NODE_VERSION: "26.x"
-  PNPM_VERSION: "11.2.2"
+  PNPM_VERSION: "12.1.0"
   SURFACE_RTT_PR_SAMPLES: "3"
 
 jobs:
@@ -63,11 +63,9 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Setup pnpm
-        shell: bash
-        run: |
-          set -euo pipefail
-          corepack enable
-          corepack prepare "pnpm@${PNPM_VERSION}" --activate
+        uses: pnpm/action-setup@v6.0.10
+        with:
+          version: ${{ env.PNPM_VERSION }}
 
       - name: Locate pnpm store
         id: pnpm-store
@@ -75,7 +73,9 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          echo "path=$(pnpm store path --silent)" >>"$GITHUB_OUTPUT"
+          store_path="$(pnpm store path --silent)"
+          test -n "$store_path"
+          printf 'path=%s\n' "$store_path" >>"$GITHUB_OUTPUT"
 
       - name: Restore pnpm store
         uses: actions/cache@v6
@@ -90,7 +90,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          time pnpm install --frozen-lockfile --prefer-offline --ignore-scripts=false --config.engine-strict=false --config.enable-pre-post-scripts=true --config.side-effects-cache=true
+          time pnpm install --frozen-lockfile --prefer-offline --config.engine-strict=false --config.enable-pre-post-scripts=true --config.side-effects-cache=true
 
       - name: Install Playwright Chromium
         working-directory: openclaw

--- a/.github/workflows/release-channel-rtt.yml
+++ b/.github/workflows/release-channel-rtt.yml
@@ -33,7 +33,7 @@ permissions:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   NODE_VERSION: "26.x"
-  PNPM_VERSION: "11.2.2"
+  PNPM_VERSION: "12.1.0"
   CHANNEL_RTT_BUILD_NODE_OPTIONS: "--max-old-space-size=16384"
   CHANNEL_RTT_MAX_ATTEMPTS: "3"
   CHANNEL_RTT_RETRY_BASE_SECONDS: "15"
@@ -125,11 +125,9 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Setup pnpm
-        shell: bash
-        run: |
-          set -euo pipefail
-          corepack enable
-          corepack prepare "pnpm@${PNPM_VERSION}" --activate
+        uses: pnpm/action-setup@v6.0.10
+        with:
+          version: ${{ env.PNPM_VERSION }}
 
       - name: Locate pnpm store
         id: pnpm-store
@@ -137,7 +135,9 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          echo "path=$(pnpm store path --silent)" >>"$GITHUB_OUTPUT"
+          store_path="$(pnpm store path --silent)"
+          test -n "$store_path"
+          printf 'path=%s\n' "$store_path" >>"$GITHUB_OUTPUT"
 
       - name: Restore pnpm store
         uses: actions/cache@v6
@@ -152,14 +152,14 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          time pnpm install --frozen-lockfile --prefer-offline --ignore-scripts=false --config.engine-strict=false --config.enable-pre-post-scripts=true --config.side-effects-cache=true
+          time pnpm install --frozen-lockfile --prefer-offline --config.engine-strict=false --config.enable-pre-post-scripts=true --config.side-effects-cache=true
 
       - name: Install OpenClaw QA harness dependencies
         working-directory: openclaw-qa
         shell: bash
         run: |
           set -euo pipefail
-          time pnpm install --frozen-lockfile --prefer-offline --ignore-scripts=false --config.engine-strict=false --config.enable-pre-post-scripts=true --config.side-effects-cache=true
+          time pnpm install --frozen-lockfile --prefer-offline --config.engine-strict=false --config.enable-pre-post-scripts=true --config.side-effects-cache=true
 
       - name: Link OpenClaw release channel package
         shell: bash

--- a/.github/workflows/release-surface-rtt.yml
+++ b/.github/workflows/release-surface-rtt.yml
@@ -33,7 +33,7 @@ permissions:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   NODE_VERSION: "26.x"
-  PNPM_VERSION: "11.2.2"
+  PNPM_VERSION: "12.1.0"
 
 jobs:
   resolve:
@@ -108,11 +108,9 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Setup pnpm
-        shell: bash
-        run: |
-          set -euo pipefail
-          corepack enable
-          corepack prepare "pnpm@${PNPM_VERSION}" --activate
+        uses: pnpm/action-setup@v6.0.10
+        with:
+          version: ${{ env.PNPM_VERSION }}
 
       - name: Locate pnpm store
         id: pnpm-store
@@ -120,7 +118,9 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          echo "path=$(pnpm store path --silent)" >>"$GITHUB_OUTPUT"
+          store_path="$(pnpm store path --silent)"
+          test -n "$store_path"
+          printf 'path=%s\n' "$store_path" >>"$GITHUB_OUTPUT"
 
       - name: Restore pnpm store
         uses: actions/cache@v6
@@ -135,7 +135,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          time pnpm install --frozen-lockfile --prefer-offline --ignore-scripts=false --config.engine-strict=false --config.enable-pre-post-scripts=true --config.side-effects-cache=true
+          time pnpm install --frozen-lockfile --prefer-offline --config.engine-strict=false --config.enable-pre-post-scripts=true --config.side-effects-cache=true
 
       - name: Install Playwright Chromium
         working-directory: openclaw

--- a/.github/workflows/stable-release-discord-rtt.yml
+++ b/.github/workflows/stable-release-discord-rtt.yml
@@ -36,7 +36,7 @@ permissions:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   NODE_VERSION: "26.x"
-  PNPM_VERSION: "11.2.2"
+  PNPM_VERSION: "12.1.0"
 
 jobs:
   resolve:
@@ -121,11 +121,9 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Setup pnpm
-        shell: bash
-        run: |
-          set -euo pipefail
-          corepack enable
-          corepack prepare "pnpm@${PNPM_VERSION}" --activate
+        uses: pnpm/action-setup@v6.0.10
+        with:
+          version: ${{ env.PNPM_VERSION }}
 
       - name: Locate pnpm store
         id: pnpm-store
@@ -133,7 +131,9 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          echo "path=$(pnpm store path --silent)" >>"$GITHUB_OUTPUT"
+          store_path="$(pnpm store path --silent)"
+          test -n "$store_path"
+          printf 'path=%s\n' "$store_path" >>"$GITHUB_OUTPUT"
 
       - name: Restore pnpm store
         uses: actions/cache@v6
@@ -148,14 +148,14 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          time pnpm install --frozen-lockfile --prefer-offline --ignore-scripts=false --config.engine-strict=false --config.enable-pre-post-scripts=true --config.side-effects-cache=true
+          time pnpm install --frozen-lockfile --prefer-offline --config.engine-strict=false --config.enable-pre-post-scripts=true --config.side-effects-cache=true
 
       - name: Install OpenClaw QA harness dependencies
         working-directory: openclaw-qa
         shell: bash
         run: |
           set -euo pipefail
-          time pnpm install --frozen-lockfile --prefer-offline --ignore-scripts=false --config.engine-strict=false --config.enable-pre-post-scripts=true --config.side-effects-cache=true
+          time pnpm install --frozen-lockfile --prefer-offline --config.engine-strict=false --config.enable-pre-post-scripts=true --config.side-effects-cache=true
 
       - name: Patch release QA compatibility
         working-directory: openclaw-rtt

--- a/.github/workflows/stable-release-rtt.yml
+++ b/.github/workflows/stable-release-rtt.yml
@@ -100,7 +100,9 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          echo "path=$(pnpm store path --silent)" >>"$GITHUB_OUTPUT"
+          store_path="$(pnpm store path --silent)"
+          test -n "$store_path"
+          printf 'path=%s\n' "$store_path" >>"$GITHUB_OUTPUT"
 
       - name: Restore pnpm store
         if: steps.release.outputs.should_run == 'true'

--- a/scripts/pnpm-store-workflow.test.mjs
+++ b/scripts/pnpm-store-workflow.test.mjs
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import test from "node:test";
+
+const execFileAsync = promisify(execFile);
+const workflowsDir = new URL("../.github/workflows/", import.meta.url);
+
+for (const filename of (await fs.readdir(workflowsDir)).filter((name) => name.endsWith(".yml"))) {
+  const workflow = await fs.readFile(new URL(filename, workflowsDir), "utf8");
+  const step = workflow.split("      - name: Locate pnpm store\n")[1]?.split("      - name:")[0];
+  if (!step) continue;
+  const script = step.split("        run: |\n")[1]?.replace(/^ {10}/gmu, "").trim();
+  assert.ok(script, `${filename} must contain a runnable store lookup`);
+
+  test(`${filename}: pnpm store lookup preserves success and rejects failed or empty output`, async (t) => {
+    const workspace = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-rtt-pnpm-store-test-"));
+    t.after(() => fs.rm(workspace, { recursive: true, force: true }));
+    const outputPath = path.join(workspace, "github-output");
+    const storePath = path.join(workspace, "store with spaces");
+    const stub = [
+      "pnpm() {",
+      '  printf "%s" "$TEST_PNPM_OUTPUT"',
+      '  return "$TEST_PNPM_EXIT"',
+      "}",
+    ].join("\n");
+
+    for (const fixture of [
+      { output: storePath, exit: "0", succeeds: true },
+      { output: storePath, exit: "17", succeeds: false },
+      { output: "", exit: "0", succeeds: false },
+    ]) {
+      await fs.writeFile(outputPath, "");
+      const result = await execFileAsync("bash", ["-c", `${stub}\n${script}`], {
+        cwd: workspace,
+        env: {
+          ...process.env,
+          GITHUB_OUTPUT: outputPath,
+          TEST_PNPM_OUTPUT: fixture.output,
+          TEST_PNPM_EXIT: fixture.exit,
+        },
+      }).then(
+        () => ({ code: 0 }),
+        (error) => ({ code: error.code }),
+      );
+      const output = await fs.readFile(outputPath, "utf8");
+      if (fixture.succeeds) {
+        assert.equal(result.code, 0);
+        assert.equal(output, `path=${storePath}\n`);
+      } else {
+        assert.equal(typeof result.code, "number");
+        assert.notEqual(result.code, 0, `must reject pnpm exit=${fixture.exit} output=${fixture.output}`);
+        assert.equal(output, "", "failed lookup must not publish a cache path");
+      }
+    }
+  });
+}


### PR DESCRIPTION
Scheduled RTT workflows fail before measurement because Corepack tries to load pnpm 12's removed `bin/pnpm.cjs`, or because pnpm 12 rejects `--ignore-scripts=false`. The store lookup also hides pnpm failures inside `echo`, producing a misleading cache-action error about a missing path.

This change uses the existing pnpm setup action across the six remaining harness workflows, removes the obsolete boolean spelling, and makes all eight store lookups reject failed or empty output before publishing the cache path. Eight regression tests execute the actual workflow shell snippets with successful, failed, and empty pnpm output. No jobs, assertions, data validation, or live probes are disabled.

Dependency refresh:

- Six harness workflow pins: pnpm 11.2.2 → 12.1.0, matching the current OpenClaw package-manager pin and the existing Telegram workflows. Reviewed the [pnpm 12 migration notes](https://github.com/pnpm/pnpm/releases/tag/v12.0.0); the workflow uses frozen installs and retains install-script execution.
- Crabbox hydration: pnpm 11.1.2 → 11.24.0, the current stable npm dist-tag. Its workspace still uses npm.
- All GitHub Action references already resolve to current releases, including the pinned Blacksmith Docker Builder commit (v2.1.0). No action updates, new dependencies, or lockfile changes are needed. The root npm manifest has no dependencies and no build script.

Validation on Node 26.8.1:

```text
$ npm test
ℹ tests 83
ℹ pass 83
ℹ fail 0
ℹ skipped 0

$ npm run check
ok: 421 RTT rows
ok: 611 Discord RTT rows
ok: 2309 Channel RTT rows
ok: 831 Surface RTT rows

$ actionlint
(no output; exit 0)
```

Live CLI proof against the repository's real imported data (these are directly executable Node scripts; no compilation step exists):

```text
$ node scripts/summary.mjs
Runs: 421
Latest: openclaw@2026.9.1-beta.1 2026.9.1-beta.1 pass canary=999ms mention=999ms p50=999ms p95=2006ms
```

A task-local pnpm 12.1.0 installation also ran a real frozen install in a temporary workspace with a postinstall hook. The workspace's lockfile was generated by pnpm before this command:

```text
$ cd .tmp/deps-refresh-20260830/fixture
$ PATH="$PWD/../pnpm12/node_modules/.bin:$PATH" pnpm install --frozen-lockfile --prefer-offline --config.engine-strict=false --config.enable-pre-post-scripts=true --config.side-effects-cache=true --store-dir "$PWD/store"
. postinstall$ node -e "console.log('postinstall ran')"
. postinstall: postinstall ran
. postinstall: Done
Already up to date
Done in 2s using pnpm v12.1.0
```

CI diagnosis and remaining limit:

- Ordinary [CI](https://github.com/openclaw/openclaw-rtt/actions/runs/33292011194) and [CodeQL](https://github.com/openclaw/openclaw-rtt/actions/runs/33292011153) are already green on their latest default-branch runs. The reported red state comes from scheduled monitoring workflows.
- [Main Channel RTT](https://github.com/openclaw/openclaw-rtt/actions/runs/33347048568) fails with `MODULE_NOT_FOUND` for `pnpm/12.1.0/bin/pnpm.cjs`, then `Input required and not supplied: path`. [Release Discord RTT](https://github.com/openclaw/openclaw-rtt/actions/runs/33347013111) fails with `unexpected value 'false' for '--ignore-scripts'`. This PR fixes those bootstrap/CLI failures.
- [Main Telegram RTT](https://github.com/openclaw/openclaw-rtt/actions/runs/33345588351) builds successfully but its external live QA command exits 1; import then fails with `telegram-reply-chain-exact-marker is missing result.timing.` The available log does not expose the underlying scenario failure, and this workflow does not upload its raw evidence. Investigating the upstream live harness/evidence needs separate follow-through. The importer remains strict. No production state or credentials were changed, and scheduled live workflows were not dispatched.

The PR does not establish that all scheduled probes are green. It is intentionally left for maintainer review and landing.

Codex autoreview completed with `scoped-clean` at the skill's default P0 threshold; no accepted/actionable findings.

Hosted verification on PR commit `f21bf403`: [CI](https://github.com/openclaw/openclaw-rtt/actions/runs/33362527290), [CodeQL](https://github.com/openclaw/openclaw-rtt/actions/runs/33362527342), and [Main Surface RTT](https://github.com/openclaw/openclaw-rtt/actions/runs/33362527301) all passed. The surface job completed pnpm setup, cache restoration, frozen OpenClaw installation, Playwright setup, and three real samples per surface on Blacksmith. Its `node scripts/surface-rtt-summary.mjs` output includes:

```text
2026-08-31T06:02:02.550Z  rpc  rpc-gateway-smoke  openclaw@main  2026.8.1+1f8ea993ef  pass  samples=3  rtt_p50=1ms  rtt_p95=1ms  rss_p50=91MB  rss_p95=112MB
2026-08-31T06:03:03.785Z  control-ui  control-ui-qa-channel-image-roundtrip  openclaw@main  2026.8.1+1f8ea993ef  pass  samples=3  rtt_p50=137ms  rtt_p95=143ms  rss_p50=519MB  rss_p95=1029MB
```
