### PR TITLE
fix(ci): restore RTT release measurements

### DIFF
--- a/.github/workflows/main-channel-rtt.yml
+++ b/.github/workflows/main-channel-rtt.yml
@@ -147,7 +147,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          time pnpm install --frozen-lockfile --prefer-offline --config.engine-strict=false --config.enable-pre-post-scripts=true --config.side-effects-cache=true
+          time pnpm install --frozen-lockfile --prefer-offline --config.manage-package-manager-versions=false --config.engine-strict=false --config.enable-pre-post-scripts=true --config.side-effects-cache=true
 
       - name: Resolve OpenClaw ref
         id: openclaw_ref

--- a/.github/workflows/main-discord-rtt.yml
+++ b/.github/workflows/main-discord-rtt.yml
@@ -78,7 +78,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          time pnpm install --frozen-lockfile --prefer-offline --config.engine-strict=false --config.enable-pre-post-scripts=true --config.side-effects-cache=true
+          time pnpm install --frozen-lockfile --prefer-offline --config.manage-package-manager-versions=false --config.engine-strict=false --config.enable-pre-post-scripts=true --config.side-effects-cache=true
 
       - name: Resolve OpenClaw ref
         id: openclaw_ref

--- a/.github/workflows/main-rtt.yml
+++ b/.github/workflows/main-rtt.yml
@@ -84,7 +84,7 @@ jobs:
         run: |
           set -euo pipefail
           echo "::group::pnpm install"
-          time pnpm install --frozen-lockfile --prefer-offline --config.engine-strict=false --config.enable-pre-post-scripts=true --config.side-effects-cache=true
+          time pnpm install --frozen-lockfile --prefer-offline --config.manage-package-manager-versions=false --config.engine-strict=false --config.enable-pre-post-scripts=true --config.side-effects-cache=true
           echo "::endgroup::"
           echo "::group::pnpm build"
           time pnpm build
@@ -126,11 +126,10 @@ jobs:
         shell: bash
         run: |
           samples="${INPUT_SAMPLES:-20}"
-          if ! [[ "$samples" =~ ^[1-9][0-9]*$ ]]; then
-            echo "samples must be a positive integer, got: $samples" >&2
-            exit 1
-          fi
           output="$RUNNER_TEMP/openclaw-rtt-runs/main"
+          evidence_path="$output/raw/qa-evidence.json"
+          metrics_path="$RUNNER_TEMP/openclaw-rtt-resource-metrics.env"
+          status=0
           rtt_env=(
             OPENCLAW_NPM_TELEGRAM_PACKAGE_SPEC="openclaw@main"
             OPENCLAW_NPM_TELEGRAM_PACKAGE_TGZ="${{ steps.pack.outputs.package_tgz }}"
@@ -140,27 +139,30 @@ jobs:
             OPENCLAW_NPM_TELEGRAM_RTT_SAMPLES="$samples"
             OPENCLAW_QA_TELEGRAM_SCENARIO_TIMEOUT_MS=240000
           )
-          metrics_path="$RUNNER_TEMP/openclaw-rtt-resource-metrics.env"
           started_at="$(node -e 'process.stdout.write(new Date().toISOString())')"
-          set +e
-          env \
-            "${rtt_env[@]}" \
-            /usr/bin/time \
-            -f 'max_rss_kb=%M\nelapsed_seconds=%e' \
-            -o "$metrics_path" \
-            pnpm test:docker:npm-telegram-live
-          status="$?"
-          set -e
+          if ! [[ "$samples" =~ ^[1-9][0-9]*$ ]]; then
+            echo "samples must be a positive integer, got: $samples" >&2
+            status=2
+          else
+            set +e
+            env \
+              "${rtt_env[@]}" \
+              /usr/bin/time \
+              -f 'max_rss_kb=%M\nelapsed_seconds=%e' \
+              -o "$metrics_path" \
+              pnpm test:docker:npm-telegram-live
+            status="$?"
+            set -e
+          fi
           finished_at="$(node -e 'process.stdout.write(new Date().toISOString())')"
-          evidence_path="$output/raw/qa-evidence.json"
           if [[ ! -f "$evidence_path" ]]; then
             echo "No qa-evidence.json produced." >&2
             if [[ "$status" -eq 0 ]]; then
               status=1
             fi
-            exit "$status"
           fi
           {
+            echo "status=$status"
             echo "evidence_path=$evidence_path"
             echo "resource_metrics_path=$metrics_path"
             echo "started_at=$started_at"
@@ -179,7 +181,26 @@ jobs:
             exit 1
           fi
 
+      - name: Upload Telegram RTT diagnostics
+        if: always()
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: main-telegram-rtt-diagnostics-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            ${{ runner.temp }}/openclaw-rtt-runs/main
+            ${{ runner.temp }}/openclaw-rtt-resource-metrics.env
+          retention-days: 14
+          if-no-files-found: warn
+
+      - name: Fail when Telegram RTT producer fails
+        if: steps.rtt.outputs.status != '0'
+        shell: bash
+        run: |
+          echo "Telegram RTT producer failed with status ${{ steps.rtt.outputs.status }}." >&2
+          exit 1
+
       - name: Import result
+        if: steps.rtt.outputs.status == '0'
         working-directory: openclaw-rtt
         shell: bash
         run: |
@@ -196,6 +217,7 @@ jobs:
           node scripts/summary.mjs
 
       - name: Commit result
+        if: steps.rtt.outputs.status == '0'
         working-directory: openclaw-rtt
         shell: bash
         run: |

--- a/.github/workflows/main-surface-rtt.yml
+++ b/.github/workflows/main-surface-rtt.yml
@@ -90,7 +90,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          time pnpm install --frozen-lockfile --prefer-offline --config.engine-strict=false --config.enable-pre-post-scripts=true --config.side-effects-cache=true
+          time pnpm install --frozen-lockfile --prefer-offline --config.manage-package-manager-versions=false --config.engine-strict=false --config.enable-pre-post-scripts=true --config.side-effects-cache=true
 
       - name: Install Playwright Chromium
         working-directory: openclaw

--- a/.github/workflows/release-channel-rtt.yml
+++ b/.github/workflows/release-channel-rtt.yml
@@ -152,14 +152,14 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          time pnpm install --frozen-lockfile --prefer-offline --config.engine-strict=false --config.enable-pre-post-scripts=true --config.side-effects-cache=true
+          time pnpm install --frozen-lockfile --prefer-offline --config.manage-package-manager-versions=false --config.engine-strict=false --config.enable-pre-post-scripts=true --config.side-effects-cache=true
 
       - name: Install OpenClaw QA harness dependencies
         working-directory: openclaw-qa
         shell: bash
         run: |
           set -euo pipefail
-          time pnpm install --frozen-lockfile --prefer-offline --config.engine-strict=false --config.enable-pre-post-scripts=true --config.side-effects-cache=true
+          time pnpm install --frozen-lockfile --prefer-offline --config.manage-package-manager-versions=false --config.engine-strict=false --config.enable-pre-post-scripts=true --config.side-effects-cache=true
 
       - name: Link OpenClaw release channel package
         shell: bash
@@ -397,6 +397,8 @@ jobs:
           path: ${{ runner.temp }}/release-channel-rtt-imports
 
       - name: Import channel release RTT results
+        env:
+          MEASURE_RESULT: ${{ needs.measure.result }}
         shell: bash
         run: |
           set -euo pipefail
@@ -408,8 +410,8 @@ jobs:
             import_dirs=("$import_root")
           fi
           if [[ "${#import_dirs[@]}" -eq 0 ]]; then
-            echo "No channel release RTT import artifacts downloaded." >&2
-            exit 1
+            node scripts/handle-missing-release-imports.mjs channel "$MEASURE_RESULT"
+            exit 0
           fi
           get_metadata() {
             local metadata_path="$1"

--- a/.github/workflows/release-surface-rtt.yml
+++ b/.github/workflows/release-surface-rtt.yml
@@ -135,7 +135,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          time pnpm install --frozen-lockfile --prefer-offline --config.engine-strict=false --config.enable-pre-post-scripts=true --config.side-effects-cache=true
+          time pnpm install --frozen-lockfile --prefer-offline --config.manage-package-manager-versions=false --config.engine-strict=false --config.enable-pre-post-scripts=true --config.side-effects-cache=true
 
       - name: Install Playwright Chromium
         working-directory: openclaw
@@ -256,6 +256,8 @@ jobs:
           path: ${{ runner.temp }}/release-surface-rtt-imports
 
       - name: Import surface release RTT results
+        env:
+          MEASURE_RESULT: ${{ needs.measure.result }}
         shell: bash
         run: |
           set -euo pipefail
@@ -267,8 +269,8 @@ jobs:
             import_dirs=("$import_root")
           fi
           if [[ "${#import_dirs[@]}" -eq 0 ]]; then
-            echo "No surface release RTT import artifacts downloaded." >&2
-            exit 1
+            node scripts/handle-missing-release-imports.mjs surface "$MEASURE_RESULT"
+            exit 0
           fi
           get_metadata() {
             local metadata_path="$1"

--- a/.github/workflows/stable-release-discord-rtt.yml
+++ b/.github/workflows/stable-release-discord-rtt.yml
@@ -110,7 +110,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           repository: openclaw/openclaw
-          ref: main
+          ref: 3100ba535f1d003d67a6a7536deacf8666367b38 # OpenClaw main, 2026-09-03
           path: openclaw-qa
           fetch-depth: 1
           persist-credentials: false
@@ -148,14 +148,14 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          time pnpm install --frozen-lockfile --prefer-offline --config.engine-strict=false --config.enable-pre-post-scripts=true --config.side-effects-cache=true
+          time pnpm install --frozen-lockfile --prefer-offline --config.manage-package-manager-versions=false --config.engine-strict=false --config.enable-pre-post-scripts=true --config.side-effects-cache=true
 
       - name: Install OpenClaw QA harness dependencies
         working-directory: openclaw-qa
         shell: bash
         run: |
           set -euo pipefail
-          time pnpm install --frozen-lockfile --prefer-offline --config.engine-strict=false --config.enable-pre-post-scripts=true --config.side-effects-cache=true
+          time pnpm install --frozen-lockfile --prefer-offline --config.manage-package-manager-versions=false --config.engine-strict=false --config.enable-pre-post-scripts=true --config.side-effects-cache=true
 
       - name: Patch release QA compatibility
         working-directory: openclaw-rtt
@@ -319,7 +319,7 @@ jobs:
     needs:
       - resolve
       - measure
-    if: always() && needs.resolve.outputs.should_run == 'true' && needs.measure.result != 'cancelled'
+    if: always() && needs.resolve.outputs.should_run == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     concurrency:
@@ -343,6 +343,8 @@ jobs:
           path: ${{ runner.temp }}/release-discord-rtt-imports
 
       - name: Import Discord release RTT results
+        env:
+          MEASURE_RESULT: ${{ needs.measure.result }}
         shell: bash
         run: |
           set -euo pipefail
@@ -354,8 +356,8 @@ jobs:
             import_dirs=("$import_root")
           fi
           if [[ "${#import_dirs[@]}" -eq 0 ]]; then
-            echo "No Discord release RTT import artifacts downloaded." >&2
-            exit 1
+            node scripts/handle-missing-release-imports.mjs Discord "$MEASURE_RESULT"
+            exit 0
           fi
           get_metadata() {
             local metadata_path="$1"

--- a/.github/workflows/stable-release-rtt.yml
+++ b/.github/workflows/stable-release-rtt.yml
@@ -119,7 +119,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          time pnpm install --frozen-lockfile --prefer-offline --config.engine-strict=false --config.enable-pre-post-scripts=true --config.side-effects-cache=true
+          time pnpm install --frozen-lockfile --prefer-offline --config.manage-package-manager-versions=false --config.engine-strict=false --config.enable-pre-post-scripts=true --config.side-effects-cache=true
 
       - name: Build OpenClaw QA harness
         if: steps.release.outputs.should_run == 'true'

--- a/scripts/handle-missing-release-imports.mjs
+++ b/scripts/handle-missing-release-imports.mjs
@@ -1,0 +1,27 @@
+function main() {
+  const [family, measureResult, ...extraArgs] = process.argv.slice(2);
+
+  if (!family || !measureResult || extraArgs.length > 0) {
+    throw new Error(
+      "Usage: node scripts/handle-missing-release-imports.mjs <family> <measure-result>",
+    );
+  }
+
+  if (measureResult === "success") {
+    throw new Error(`No ${family} release RTT import artifacts arrived after a successful matrix.`);
+  }
+  if (measureResult !== "failure" && measureResult !== "cancelled") {
+    throw new Error(`Unexpected ${family} release RTT measure result: ${measureResult}`);
+  }
+
+  process.stdout.write(
+    `::notice title=${family} release RTT import skipped::No import artifacts arrived; measure matrix result was ${measureResult}.\n`,
+  );
+}
+
+try {
+  main();
+} catch (error) {
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+  process.exitCode = 1;
+}

--- a/scripts/patch-openclaw-release-qa-harness.mjs
+++ b/scripts/patch-openclaw-release-qa-harness.mjs
@@ -4,42 +4,58 @@ import { fileURLToPath } from "node:url";
 
 const PATCH_ASSET_ROOT = path.dirname(fileURLToPath(import.meta.url));
 
-const gatewayConfigWriteAnchor = `      await fs.writeFile(configPath, \`\${JSON.stringify(cfg, null, 2)}\\n\`, {
-        encoding: "utf8",
-        mode: 0o600,
-      });`;
-const adaptedGatewayConfigWrite = `      const releaseCompatibleConfig = (
-        await import("./rtt-release-qa-config-compat.mjs")
-      ).adaptReleaseGatewayConfig(cfg, process.env.OPENCLAW_QA_RELEASE_PACKAGE_SPEC);
-      await fs.writeFile(configPath, \`\${JSON.stringify(releaseCompatibleConfig, null, 2)}\\n\`, {
-        encoding: "utf8",
-        mode: 0o600,
-      });`;
+const gatewayConfigWriteAnchor = `        await fs.writeFile(configPath, \`\${JSON.stringify(cfg, null, 2)}\\n\`, {
+          encoding: "utf8",
+          mode: 0o600,
+        });`;
+const adaptedGatewayConfigWrite = `        const releaseCompatibleConfig = (
+          await import("./rtt-release-qa-config-compat.mjs")
+        ).adaptReleaseGatewayConfig(cfg, process.env.OPENCLAW_QA_RELEASE_PACKAGE_SPEC);
+        await fs.writeFile(configPath, \`\${JSON.stringify(releaseCompatibleConfig, null, 2)}\\n\`, {
+          encoding: "utf8",
+          mode: 0o600,
+        });`;
 const authStoreWriteAnchor = `export async function writeQaAuthProfiles(params: {
-  agentDir: string;
+  agentId: string;
   profiles: Record<string, QaAuthProfileCredential>;
   replace?: boolean;
+  stateDir: string;
 }): Promise<void> {
-  const existing = loadAuthProfileStoreWithoutExternalProfiles(params.agentDir, {
-    inheritedAuthDir: params.agentDir,
+  const agentDir = resolveQaAgentAuthDir(params);
+  // Surface pending legacy-source errors before the locked updater, whose
+  // public failure contract is intentionally nullable.
+  loadAuthProfileStoreWithoutExternalProfiles(agentDir, { inheritedAuthDir: agentDir });
+  const updated = await updateAuthProfileStoreWithLock({
+    agentDir,
+    stateDir: params.stateDir,
+    saveOptions: {
+      filterExternalAuthProfiles: false,
+      syncExternalCli: false,
+    },
+    updater: (store) => {
+      store.version = 1;
+      store.profiles = params.replace
+        ? { ...params.profiles }
+        : { ...store.profiles, ...params.profiles };
+      if (params.replace) {
+        delete store.order;
+        delete store.lastGood;
+        delete store.usageStats;
+      }
+      return true;
+    },
   });
-  const nextStore: AuthProfileStore = params.replace
-    ? { version: 1, profiles: params.profiles as AuthProfileStore["profiles"] }
-    : {
-        ...existing,
-        version: 1,
-        profiles: { ...existing.profiles, ...params.profiles } as AuthProfileStore["profiles"],
-      };
-  saveAuthProfileStore(nextStore, params.agentDir, {
-    filterExternalAuthProfiles: false,
-    syncExternalCli: false,
-  });
+  if (!updated) {
+    throw new Error("Failed to stage the isolated QA auth profile store.");
+  }
 }`;
 const candidateOwnedAuthStoreWrite = `export async function writeQaAuthProfiles(params: {
-  agentDir: string;
+  agentId: string;
   profiles: Record<string, QaAuthProfileCredential>;
   replace?: boolean;
+  stateDir: string;
 }): Promise<void> {
+  const agentDir = resolveQaAgentAuthDir(params);
   const releaseCompat = await import("../../rtt-release-qa-config-compat.mjs");
   const packageSpec = process.env.OPENCLAW_QA_RELEASE_PACKAGE_SPEC;
   const runtimePath = process.env.OPENCLAW_QA_RELEASE_AUTH_RUNTIME_PATH;
@@ -47,41 +63,70 @@ const candidateOwnedAuthStoreWrite = `export async function writeQaAuthProfiles(
     packageSpec,
     runtimePath,
   );
-  const previousStateDir = process.env.OPENCLAW_STATE_DIR;
-  if (releaseAuthRuntimePath) {
-    process.env.OPENCLAW_STATE_DIR = path.resolve(params.agentDir, "../../..");
+  if (!releaseAuthRuntimePath) {
+    loadAuthProfileStoreWithoutExternalProfiles(agentDir, { inheritedAuthDir: agentDir });
+    const updated = await updateAuthProfileStoreWithLock({
+      agentDir,
+      stateDir: params.stateDir,
+      saveOptions: {
+        filterExternalAuthProfiles: false,
+        syncExternalCli: false,
+      },
+      updater: (store) => {
+        store.version = 1;
+        store.profiles = params.replace
+          ? { ...params.profiles }
+          : { ...store.profiles, ...params.profiles };
+        if (params.replace) {
+          delete store.order;
+          delete store.lastGood;
+          delete store.usageStats;
+        }
+        return true;
+      },
+    });
+    if (!updated) {
+      throw new Error("Failed to stage the isolated QA auth profile store.");
+    }
+    return;
   }
+  const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+  process.env.OPENCLAW_STATE_DIR = params.stateDir;
   try {
     // Candidate modules cache state paths during evaluation, so the isolated QA
     // state root must be active before importing the candidate serializer.
-    const releaseAuthRuntime = releaseAuthRuntimePath
-      ? await releaseCompat.resolveReleaseAuthRuntime(packageSpec, runtimePath)
-      : undefined;
+    const releaseAuthRuntime = await releaseCompat.resolveReleaseAuthRuntime(packageSpec, runtimePath);
     const loadStore =
       releaseAuthRuntime?.loadAuthProfileStoreWithoutExternalProfiles ??
       loadAuthProfileStoreWithoutExternalProfiles;
-    const saveStore = releaseAuthRuntime?.saveAuthProfileStore ?? saveAuthProfileStore;
-    const existing = loadStore(params.agentDir, {
-      inheritedAuthDir: params.agentDir,
+    const saveStore = releaseAuthRuntime?.saveAuthProfileStore;
+    if (!saveStore) {
+      throw new Error("Candidate release auth runtime does not export saveAuthProfileStore.");
+    }
+    const existing = loadStore(agentDir, {
+      inheritedAuthDir: agentDir,
     });
-    const nextStore: AuthProfileStore = params.replace
-      ? { version: 1, profiles: params.profiles as AuthProfileStore["profiles"] }
-      : {
-          ...existing,
-          version: 1,
-          profiles: { ...existing.profiles, ...params.profiles } as AuthProfileStore["profiles"],
-        };
-    saveStore(nextStore, params.agentDir, {
+    const nextStore = {
+      ...existing,
+      version: 1,
+      profiles: params.replace
+        ? { ...params.profiles }
+        : { ...existing.profiles, ...params.profiles },
+    };
+    if (params.replace) {
+      delete nextStore.order;
+      delete nextStore.lastGood;
+      delete nextStore.usageStats;
+    }
+    saveStore(nextStore, agentDir, {
       filterExternalAuthProfiles: false,
       syncExternalCli: false,
     });
   } finally {
-    if (releaseAuthRuntimePath) {
-      if (previousStateDir === undefined) {
-        delete process.env.OPENCLAW_STATE_DIR;
-      } else {
-        process.env.OPENCLAW_STATE_DIR = previousStateDir;
-      }
+    if (previousStateDir === undefined) {
+      delete process.env.OPENCLAW_STATE_DIR;
+    } else {
+      process.env.OPENCLAW_STATE_DIR = previousStateDir;
     }
   }
 }`;
@@ -179,7 +224,10 @@ async function main() {
     throw new Error(usage());
   }
 
-  const gatewayChildPath = path.resolve(repoRoot, "extensions/qa-lab/src/gateway-child.ts");
+  const gatewaySetupPath = path.resolve(
+    repoRoot,
+    "extensions/qa-lab/src/gateway-child-setup.ts",
+  );
   const authStorePath = path.resolve(
     repoRoot,
     "extensions/qa-lab/src/providers/shared/auth-store.ts",
@@ -196,16 +244,16 @@ async function main() {
     repoRoot,
     "extensions/qa-lab/src/rtt-release-qa-config-compat.d.mts",
   );
-  const [originalGatewayChild, originalAuthStore, originalLiveGatewayConfig] = await Promise.all([
-    fs.readFile(gatewayChildPath, "utf8"),
+  const [originalGatewaySetup, originalAuthStore, originalLiveGatewayConfig] = await Promise.all([
+    fs.readFile(gatewaySetupPath, "utf8"),
     fs.readFile(authStorePath, "utf8"),
     fs.readFile(liveGatewayConfigPath, "utf8"),
   ]);
   const gatewayPatch = replaceExactlyOnce(
-    originalGatewayChild,
+    originalGatewaySetup,
     gatewayConfigWriteAnchor,
     adaptedGatewayConfigWrite,
-    gatewayChildPath,
+    gatewaySetupPath,
     "gateway config",
   );
   const authStorePatch = replaceExactlyOnce(
@@ -242,7 +290,7 @@ async function main() {
 
   const writes = [];
   if (gatewayPatch.patched) {
-    writes.push(fs.writeFile(gatewayChildPath, gatewayPatch.contents));
+    writes.push(fs.writeFile(gatewaySetupPath, gatewayPatch.contents));
   }
   if (authStorePatch.patched) {
     writes.push(fs.writeFile(authStorePath, authStorePatch.contents));

--- a/scripts/patch-openclaw-release-qa-harness.test.mjs
+++ b/scripts/patch-openclaw-release-qa-harness.test.mjs
@@ -11,32 +11,46 @@ const execFileAsync = promisify(execFile);
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const PATCH_SCRIPT = path.join(REPO_ROOT, "scripts/patch-openclaw-release-qa-harness.mjs");
 
-const gatewayChild = `async function startGateway(configPath, cfg) {
-      await fs.writeFile(configPath, \`\${JSON.stringify(cfg, null, 2)}\\n\`, {
-        encoding: "utf8",
-        mode: 0o600,
-      });
+const gatewaySetup = `async function prepareAttempt(configPath, cfg) {
+        await fs.writeFile(configPath, \`\${JSON.stringify(cfg, null, 2)}\\n\`, {
+          encoding: "utf8",
+          mode: 0o600,
+        });
 }
 `;
 const authStore = `export async function writeQaAuthProfiles(params: {
-  agentDir: string;
+  agentId: string;
   profiles: Record<string, QaAuthProfileCredential>;
   replace?: boolean;
+  stateDir: string;
 }): Promise<void> {
-  const existing = loadAuthProfileStoreWithoutExternalProfiles(params.agentDir, {
-    inheritedAuthDir: params.agentDir,
+  const agentDir = resolveQaAgentAuthDir(params);
+  // Surface pending legacy-source errors before the locked updater, whose
+  // public failure contract is intentionally nullable.
+  loadAuthProfileStoreWithoutExternalProfiles(agentDir, { inheritedAuthDir: agentDir });
+  const updated = await updateAuthProfileStoreWithLock({
+    agentDir,
+    stateDir: params.stateDir,
+    saveOptions: {
+      filterExternalAuthProfiles: false,
+      syncExternalCli: false,
+    },
+    updater: (store) => {
+      store.version = 1;
+      store.profiles = params.replace
+        ? { ...params.profiles }
+        : { ...store.profiles, ...params.profiles };
+      if (params.replace) {
+        delete store.order;
+        delete store.lastGood;
+        delete store.usageStats;
+      }
+      return true;
+    },
   });
-  const nextStore: AuthProfileStore = params.replace
-    ? { version: 1, profiles: params.profiles as AuthProfileStore["profiles"] }
-    : {
-        ...existing,
-        version: 1,
-        profiles: { ...existing.profiles, ...params.profiles } as AuthProfileStore["profiles"],
-      };
-  saveAuthProfileStore(nextStore, params.agentDir, {
-    filterExternalAuthProfiles: false,
-    syncExternalCli: false,
-  });
+  if (!updated) {
+    throw new Error("Failed to stage the isolated QA auth profile store.");
+  }
 }
 `;
 const liveGatewayConfig = `import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
@@ -75,12 +89,12 @@ export async function patchLiveQaGatewayConfig(params) {
 `;
 
 async function makeFixture({
-  gateway = gatewayChild,
+  gateway = gatewaySetup,
   auth = authStore,
   liveGateway = liveGatewayConfig,
 } = {}) {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-release-qa-patch-test-"));
-  const gatewayPath = path.join(root, "extensions/qa-lab/src/gateway-child.ts");
+  const gatewayPath = path.join(root, "extensions/qa-lab/src/gateway-child-setup.ts");
   const authPath = path.join(root, "extensions/qa-lab/src/providers/shared/auth-store.ts");
   const liveGatewayPath = path.join(
     root,
@@ -111,12 +125,13 @@ test("patches release config and auth serialization contracts idempotently", asy
 
   const patchedAuth = await fs.readFile(authPath, "utf8");
   assert.match(patchedAuth, /OPENCLAW_QA_RELEASE_AUTH_RUNTIME_PATH/u);
-  assert.match(patchedAuth, /releaseAuthRuntime\?\.saveAuthProfileStore \?\? saveAuthProfileStore/u);
-  assert.match(patchedAuth, /process\.env\.OPENCLAW_STATE_DIR = path\.resolve/u);
+  assert.match(patchedAuth, /releaseAuthRuntime\?\.saveAuthProfileStore/u);
+  assert.match(patchedAuth, /process\.env\.OPENCLAW_STATE_DIR = params\.stateDir/u);
   assert.ok(
-    patchedAuth.indexOf("process.env.OPENCLAW_STATE_DIR = path.resolve") <
+    patchedAuth.indexOf("process.env.OPENCLAW_STATE_DIR = params.stateDir") <
       patchedAuth.indexOf("await releaseCompat.resolveReleaseAuthRuntime"),
   );
+  assert.match(patchedAuth, /updateAuthProfileStoreWithLock/u);
 
   const patchedLiveGateway = await fs.readFile(liveGatewayPath, "utf8");
   assert.match(patchedLiveGateway, /function isUnsupportedReplacePathsError/u);

--- a/scripts/pnpm-store-workflow.test.mjs
+++ b/scripts/pnpm-store-workflow.test.mjs
@@ -8,6 +8,25 @@ import test from "node:test";
 
 const execFileAsync = promisify(execFile);
 const workflowsDir = new URL("../.github/workflows/", import.meta.url);
+const MANAGE_VERSION_SETTING = "--config.manage-package-manager-versions=false";
+
+test("workflow-owned pnpm remains authoritative during every OpenClaw install", async () => {
+  let installCount = 0;
+  for (const filename of (await fs.readdir(workflowsDir)).filter((name) => name.endsWith(".yml"))) {
+    const workflow = await fs.readFile(new URL(filename, workflowsDir), "utf8");
+    const installLines = workflow
+      .split("\n")
+      .filter((line) => /^\s*time pnpm install\b/u.test(line));
+    installCount += installLines.length;
+    for (const line of installLines) {
+      assert.ok(
+        line.includes(MANAGE_VERSION_SETTING),
+        `${filename} must disable packageManager-driven pnpm switching`,
+      );
+    }
+  }
+  assert.ok(installCount > 0, "expected at least one workflow pnpm install");
+});
 
 for (const filename of (await fs.readdir(workflowsDir)).filter((name) => name.endsWith(".yml"))) {
   const workflow = await fs.readFile(new URL(filename, workflowsDir), "utf8");

--- a/scripts/release-report-workflow.test.mjs
+++ b/scripts/release-report-workflow.test.mjs
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import test from "node:test";
+
+const execFileAsync = promisify(execFile);
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const HELPER_PATH = path.join(REPO_ROOT, "scripts/handle-missing-release-imports.mjs");
+const OPENCLAW_QA_SHA = "3100ba535f1d003d67a6a7536deacf8666367b38";
+const WORKFLOWS = [
+  {
+    family: "surface",
+    path: ".github/workflows/release-surface-rtt.yml",
+  },
+  {
+    family: "channel",
+    path: ".github/workflows/release-channel-rtt.yml",
+  },
+  {
+    family: "Discord",
+    path: ".github/workflows/stable-release-discord-rtt.yml",
+  },
+];
+
+test("missing release imports fail only after a successful matrix", async () => {
+  for (const result of ["failure", "cancelled"]) {
+    const { stdout, stderr } = await execFileAsync(process.execPath, [
+      HELPER_PATH,
+      "surface",
+      result,
+    ]);
+    assert.equal(stderr, "");
+    assert.match(stdout, new RegExp(`::notice .*matrix result was ${result}`, "u"));
+  }
+
+  await assert.rejects(
+    execFileAsync(process.execPath, [HELPER_PATH, "surface", "success"]),
+    /No surface release RTT import artifacts arrived after a successful matrix/u,
+  );
+  await assert.rejects(
+    execFileAsync(process.execPath, [HELPER_PATH, "surface", "skipped"]),
+    /Unexpected surface release RTT measure result: skipped/u,
+  );
+});
+
+test("release report workflows preserve partial imports without cascade failures", async () => {
+  for (const workflow of WORKFLOWS) {
+    const contents = await fs.readFile(path.join(REPO_ROOT, workflow.path), "utf8");
+    assert.match(contents, /MEASURE_RESULT: \$\{\{ needs\.measure\.result \}\}/u);
+    assert.match(
+      contents,
+      new RegExp(
+        `node scripts/handle-missing-release-imports\\.mjs ${workflow.family} "\\$MEASURE_RESULT"`,
+        "u",
+      ),
+    );
+    assert.doesNotMatch(contents, /needs\.measure\.result != 'cancelled'/u);
+  }
+});
+
+test("Discord release QA compatibility is pinned to the tested OpenClaw source", async () => {
+  const workflow = await fs.readFile(
+    path.join(REPO_ROOT, ".github/workflows/stable-release-discord-rtt.yml"),
+    "utf8",
+  );
+  const qaCheckout = workflow
+    .split("      - name: Checkout OpenClaw QA harness\n")[1]
+    ?.split("      - name:")[0];
+  assert.ok(qaCheckout, "Discord release workflow must checkout the QA harness");
+  assert.match(qaCheckout, new RegExp(`ref: ${OPENCLAW_QA_SHA}`, "u"));
+  assert.doesNotMatch(qaCheckout, /ref: main/u);
+});

--- a/scripts/telegram-rtt-workflow-contract.test.mjs
+++ b/scripts/telegram-rtt-workflow-contract.test.mjs
@@ -75,6 +75,29 @@ test("Telegram RTT workflows use the upstream harness contract", async () => {
       /working-directory: openclaw[\s\S]*git status --porcelain[\s\S]*git status --short[\s\S]*exit 1/u,
     );
   }
+
+  const mainWorkflow = workflows[0].contents;
+  const runStep = mainWorkflow
+    .split("      - name: Run RTT\n")[1]
+    ?.split("      - name: Verify OpenClaw checkout is clean\n")[0];
+  assert.ok(runStep, "main RTT workflow must contain the producer step");
+  assert.match(runStep, /echo "status=\$status"/u);
+  assert.doesNotMatch(runStep, /exit "\$status"/u);
+  assert.match(mainWorkflow, /- name: Upload Telegram RTT diagnostics[\s\S]*if: always\(\)/u);
+  assert.match(mainWorkflow, /\$\{\{ runner\.temp \}\}\/openclaw-rtt-runs\/main/u);
+  assert.match(mainWorkflow, /\$\{\{ runner\.temp \}\}\/openclaw-rtt-resource-metrics\.env/u);
+  assert.match(
+    mainWorkflow,
+    /- name: Fail when Telegram RTT producer fails[\s\S]*if: steps\.rtt\.outputs\.status != '0'[\s\S]*producer failed with status \$\{\{ steps\.rtt\.outputs\.status \}\}[\s\S]*exit 1/u,
+  );
+  assert.match(
+    mainWorkflow,
+    /- name: Import result\n\s+if: steps\.rtt\.outputs\.status == '0'/u,
+  );
+  assert.match(
+    mainWorkflow,
+    /- name: Commit result\n\s+if: steps\.rtt\.outputs\.status == '0'/u,
+  );
 });
 
 test("retired Telegram harness helpers are absent and unreferenced", async () => {


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where scheduled release RTT matrices failed while installing historical OpenClaw tags, then emitted secondary missing-artifact failures that obscured the producer error. It also fixes Main Telegram RTT runs losing their real QA failure behind a result-import timing error.

## Why This Change Was Made

The workflows now keep their installed pnpm version authoritative instead of switching to historical package-manager wrappers, retain partial release imports without manufacturing cascade failures, and always preserve Main Telegram diagnostics before failing on the producer status.

The Discord historical-release compatibility patch is refreshed against and temporarily pinned to OpenClaw `3100ba535f1d003d67a6a7536deacf8666367b38`. A stable upstream QA compatibility hook remains the durable follow-up; this pin prevents scheduled source drift meanwhile.

## User Impact

Operators get the actual failing measurement step and downloadable Telegram QA diagnostics. Historical release matrices can install with the workflow-owned pnpm, and failed matrices no longer add misleading report-job failures when no import artifact exists.

## Evidence

- `actionlint -color`
- `node --check scripts/*.mjs`
- `node --test scripts/*.test.mjs` (87/87 passing)
- `node scripts/validate.mjs` (4,238 rows validated)
- `node scripts/update-readme.mjs && git diff --exit-code README.md`
- `git diff --check`
- structured autoreview: clean, no actionable findings, confidence 0.87
- refreshed QA patch applies cleanly and idempotently to the pinned OpenClaw source

Live failures addressed:

- Main RTT: https://github.com/openclaw/openclaw-rtt/actions/runs/33700720420
- Release Surface RTT: https://github.com/openclaw/openclaw-rtt/actions/runs/33702490653
- Release Discord RTT: https://github.com/openclaw/openclaw-rtt/actions/runs/33702663172
- Release Channel RTT: https://github.com/openclaw/openclaw-rtt/actions/runs/33702779326
