### PR TITLE
fix(ci): disable pnpm version switching before startup

### DIFF
--- a/.github/workflows/main-channel-rtt.yml
+++ b/.github/workflows/main-channel-rtt.yml
@@ -29,6 +29,7 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   NODE_VERSION: "26.x"
   PNPM_VERSION: "12.1.0"
+  PNPM_CONFIG_MANAGE_PACKAGE_MANAGER_VERSIONS: "false"
   CHANNEL_RTT_PR_SAMPLES: "3"
   CHANNEL_RTT_MAX_ATTEMPTS: "3"
   CHANNEL_RTT_RETRY_BASE_SECONDS: "15"
@@ -147,7 +148,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          time pnpm install --frozen-lockfile --prefer-offline --config.manage-package-manager-versions=false --config.engine-strict=false --config.enable-pre-post-scripts=true --config.side-effects-cache=true
+          time pnpm install --frozen-lockfile --prefer-offline --config.engine-strict=false --config.enable-pre-post-scripts=true --config.side-effects-cache=true
 
       - name: Resolve OpenClaw ref
         id: openclaw_ref

--- a/.github/workflows/main-discord-rtt.yml
+++ b/.github/workflows/main-discord-rtt.yml
@@ -22,6 +22,7 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   NODE_VERSION: "26.x"
   PNPM_VERSION: "12.1.0"
+  PNPM_CONFIG_MANAGE_PACKAGE_MANAGER_VERSIONS: "false"
 
 jobs:
   measure:
@@ -78,7 +79,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          time pnpm install --frozen-lockfile --prefer-offline --config.manage-package-manager-versions=false --config.engine-strict=false --config.enable-pre-post-scripts=true --config.side-effects-cache=true
+          time pnpm install --frozen-lockfile --prefer-offline --config.engine-strict=false --config.enable-pre-post-scripts=true --config.side-effects-cache=true
 
       - name: Resolve OpenClaw ref
         id: openclaw_ref

--- a/.github/workflows/main-rtt.yml
+++ b/.github/workflows/main-rtt.yml
@@ -22,6 +22,7 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   NODE_VERSION: "26.x"
   PNPM_VERSION: "12.1.0"
+  PNPM_CONFIG_MANAGE_PACKAGE_MANAGER_VERSIONS: "false"
 
 jobs:
   measure:
@@ -84,7 +85,7 @@ jobs:
         run: |
           set -euo pipefail
           echo "::group::pnpm install"
-          time pnpm install --frozen-lockfile --prefer-offline --config.manage-package-manager-versions=false --config.engine-strict=false --config.enable-pre-post-scripts=true --config.side-effects-cache=true
+          time pnpm install --frozen-lockfile --prefer-offline --config.engine-strict=false --config.enable-pre-post-scripts=true --config.side-effects-cache=true
           echo "::endgroup::"
           echo "::group::pnpm build"
           time pnpm build

--- a/.github/workflows/main-surface-rtt.yml
+++ b/.github/workflows/main-surface-rtt.yml
@@ -33,6 +33,7 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   NODE_VERSION: "26.x"
   PNPM_VERSION: "12.1.0"
+  PNPM_CONFIG_MANAGE_PACKAGE_MANAGER_VERSIONS: "false"
   SURFACE_RTT_PR_SAMPLES: "3"
 
 jobs:
@@ -92,7 +93,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          time pnpm install --frozen-lockfile --prefer-offline --config.manage-package-manager-versions=false --config.engine-strict=false --config.enable-pre-post-scripts=true --config.side-effects-cache=true
+          time pnpm install --frozen-lockfile --prefer-offline --config.engine-strict=false --config.enable-pre-post-scripts=true --config.side-effects-cache=true
 
       - name: Install Playwright Chromium
         working-directory: openclaw

--- a/.github/workflows/release-channel-rtt.yml
+++ b/.github/workflows/release-channel-rtt.yml
@@ -34,6 +34,7 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   NODE_VERSION: "26.x"
   PNPM_VERSION: "12.1.0"
+  PNPM_CONFIG_MANAGE_PACKAGE_MANAGER_VERSIONS: "false"
   CHANNEL_RTT_BUILD_NODE_OPTIONS: "--max-old-space-size=16384"
   CHANNEL_RTT_MAX_ATTEMPTS: "3"
   CHANNEL_RTT_RETRY_BASE_SECONDS: "15"
@@ -152,14 +153,14 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          time pnpm install --frozen-lockfile --prefer-offline --config.manage-package-manager-versions=false --config.engine-strict=false --config.enable-pre-post-scripts=true --config.side-effects-cache=true
+          time pnpm install --frozen-lockfile --prefer-offline --config.engine-strict=false --config.enable-pre-post-scripts=true --config.side-effects-cache=true
 
       - name: Install OpenClaw QA harness dependencies
         working-directory: openclaw-qa
         shell: bash
         run: |
           set -euo pipefail
-          time pnpm install --frozen-lockfile --prefer-offline --config.manage-package-manager-versions=false --config.engine-strict=false --config.enable-pre-post-scripts=true --config.side-effects-cache=true
+          time pnpm install --frozen-lockfile --prefer-offline --config.engine-strict=false --config.enable-pre-post-scripts=true --config.side-effects-cache=true
 
       - name: Link OpenClaw release channel package
         shell: bash

--- a/.github/workflows/release-surface-rtt.yml
+++ b/.github/workflows/release-surface-rtt.yml
@@ -34,6 +34,7 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   NODE_VERSION: "26.x"
   PNPM_VERSION: "12.1.0"
+  PNPM_CONFIG_MANAGE_PACKAGE_MANAGER_VERSIONS: "false"
 
 jobs:
   resolve:
@@ -135,7 +136,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          time pnpm install --frozen-lockfile --prefer-offline --config.manage-package-manager-versions=false --config.engine-strict=false --config.enable-pre-post-scripts=true --config.side-effects-cache=true
+          time pnpm install --frozen-lockfile --prefer-offline --config.engine-strict=false --config.enable-pre-post-scripts=true --config.side-effects-cache=true
 
       - name: Install Playwright Chromium
         working-directory: openclaw

--- a/.github/workflows/stable-release-discord-rtt.yml
+++ b/.github/workflows/stable-release-discord-rtt.yml
@@ -37,6 +37,7 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   NODE_VERSION: "26.x"
   PNPM_VERSION: "12.1.0"
+  PNPM_CONFIG_MANAGE_PACKAGE_MANAGER_VERSIONS: "false"
 
 jobs:
   resolve:
@@ -148,14 +149,14 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          time pnpm install --frozen-lockfile --prefer-offline --config.manage-package-manager-versions=false --config.engine-strict=false --config.enable-pre-post-scripts=true --config.side-effects-cache=true
+          time pnpm install --frozen-lockfile --prefer-offline --config.engine-strict=false --config.enable-pre-post-scripts=true --config.side-effects-cache=true
 
       - name: Install OpenClaw QA harness dependencies
         working-directory: openclaw-qa
         shell: bash
         run: |
           set -euo pipefail
-          time pnpm install --frozen-lockfile --prefer-offline --config.manage-package-manager-versions=false --config.engine-strict=false --config.enable-pre-post-scripts=true --config.side-effects-cache=true
+          time pnpm install --frozen-lockfile --prefer-offline --config.engine-strict=false --config.enable-pre-post-scripts=true --config.side-effects-cache=true
 
       - name: Patch release QA compatibility
         working-directory: openclaw-rtt

--- a/.github/workflows/stable-release-rtt.yml
+++ b/.github/workflows/stable-release-rtt.yml
@@ -40,6 +40,7 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   NODE_VERSION: "26.x"
   PNPM_VERSION: "12.1.0"
+  PNPM_CONFIG_MANAGE_PACKAGE_MANAGER_VERSIONS: "false"
 
 jobs:
   measure:
@@ -119,7 +120,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          time pnpm install --frozen-lockfile --prefer-offline --config.manage-package-manager-versions=false --config.engine-strict=false --config.enable-pre-post-scripts=true --config.side-effects-cache=true
+          time pnpm install --frozen-lockfile --prefer-offline --config.engine-strict=false --config.enable-pre-post-scripts=true --config.side-effects-cache=true
 
       - name: Build OpenClaw QA harness
         if: steps.release.outputs.should_run == 'true'

--- a/scripts/pnpm-store-workflow.test.mjs
+++ b/scripts/pnpm-store-workflow.test.mjs
@@ -8,7 +8,8 @@ import test from "node:test";
 
 const execFileAsync = promisify(execFile);
 const workflowsDir = new URL("../.github/workflows/", import.meta.url);
-const MANAGE_VERSION_SETTING = "--config.manage-package-manager-versions=false";
+const MANAGE_VERSION_ENV = 'PNPM_CONFIG_MANAGE_PACKAGE_MANAGER_VERSIONS: "false"';
+const LATE_MANAGE_VERSION_SETTING = "--config.manage-package-manager-versions=false";
 
 test("workflow-owned pnpm remains authoritative during every OpenClaw install", async () => {
   let installCount = 0;
@@ -18,12 +19,17 @@ test("workflow-owned pnpm remains authoritative during every OpenClaw install", 
       .split("\n")
       .filter((line) => /^\s*time pnpm install\b/u.test(line));
     installCount += installLines.length;
-    for (const line of installLines) {
-      assert.ok(
-        line.includes(MANAGE_VERSION_SETTING),
-        `${filename} must disable packageManager-driven pnpm switching`,
-      );
-    }
+    if (installLines.length === 0) continue;
+
+    const workflowHeader = workflow.split("\njobs:\n", 1)[0];
+    assert.ok(
+      workflowHeader.includes(MANAGE_VERSION_ENV),
+      `${filename} must disable packageManager-driven pnpm switching before pnpm starts`,
+    );
+    assert.ok(
+      installLines.every((line) => !line.includes(LATE_MANAGE_VERSION_SETTING)),
+      `${filename} must not rely on the install command to disable pnpm version switching`,
+    );
   }
   assert.ok(installCount > 0, "expected at least one workflow pnpm install");
 });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where historical OpenClaw release RTT jobs still switched from workflow-owned pnpm 12 to a release-pinned pnpm 11 engine, then failed because the generated wrapper was unavailable.

## Why This Change Was Made

pnpm evaluates package-manager switching before the install command runs. The workflows now set `PNPM_CONFIG_MANAGE_PACKAGE_MANAGER_VERSIONS=false` at workflow startup and remove the ineffective late CLI flag.

Caching and the selected pnpm version remain unchanged.

## User Impact

Historical release Surface, Channel, Discord, and Telegram measurements can install with the workflow-owned pnpm instead of failing before the RTT scenario starts.

## Evidence

Live proof that the prior CLI setting was too late:

- Surface: https://github.com/openclaw/openclaw-rtt/actions/runs/33711936908
- Channel: https://github.com/openclaw/openclaw-rtt/actions/runs/33711936676
- Discord old release leg: https://github.com/openclaw/openclaw-rtt/actions/runs/33711936886

Source contract:

- pnpm recognizes `PNPM_CONFIG_MANAGE_PACKAGE_MANAGER_VERSIONS=false` before pre-command version reconciliation: https://github.com/pnpm/pnpm/blob/ce66a532d4b942127b5147732ffc5aa2df91786b/pnpm/crates/cli/src/cli_args/package_manager.rs
- pre-command switching reads that process state before executing the requested command: https://github.com/pnpm/pnpm/blob/ce66a532d4b942127b5147732ffc5aa2df91786b/pnpm/crates/cli/src/cli_args/pre_command.rs

Validation:

- `actionlint -color`
- `node --check scripts/*.mjs`
- focused workflow tests: 9/9 passing
- `node --test scripts/*.test.mjs`: 90/90 passing
- `node scripts/validate.mjs`: 4,238 rows validated
- README regeneration unchanged
- `git diff --check`
- structured autoreview: clean, no actionable findings, confidence 0.91
