### PR TITLE
fix(ci): measure correction releases by tag

### DIFF
--- a/.github/workflows/release-channel-rtt.yml
+++ b/.github/workflows/release-channel-rtt.yml
@@ -191,9 +191,11 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          version="$(node -p "require('./package.json').version")"
-          if [[ "$version" != "${{ matrix.package.version }}" ]]; then
-            echo "OpenClaw package version mismatch: expected ${{ matrix.package.version }}, got ${version}" >&2
+          tag_ref="refs/tags/${{ matrix.package.tag }}"
+          head_commit="$(git rev-parse HEAD)"
+          tag_commit="$(git rev-parse --verify "${tag_ref}^{commit}")"
+          if [[ "$head_commit" != "$tag_commit" ]]; then
+            echo "OpenClaw release ref mismatch: HEAD ${head_commit} does not match ${tag_ref} (${tag_commit})" >&2
             exit 1
           fi
 

--- a/.github/workflows/release-surface-rtt.yml
+++ b/.github/workflows/release-surface-rtt.yml
@@ -143,16 +143,18 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          node --import tsx scripts/ensure-playwright-chromium.mts
+          pnpm exec playwright-core install chromium
 
       - name: Verify OpenClaw release ref
         working-directory: openclaw
         shell: bash
         run: |
           set -euo pipefail
-          version="$(node -p "require('./package.json').version")"
-          if [[ "$version" != "${{ matrix.package.version }}" ]]; then
-            echo "OpenClaw package version mismatch: expected ${{ matrix.package.version }}, got ${version}" >&2
+          tag_ref="refs/tags/${{ matrix.package.tag }}"
+          head_commit="$(git rev-parse HEAD)"
+          tag_commit="$(git rev-parse --verify "${tag_ref}^{commit}")"
+          if [[ "$head_commit" != "$tag_commit" ]]; then
+            echo "OpenClaw release ref mismatch: HEAD ${head_commit} does not match ${tag_ref} (${tag_commit})" >&2
             exit 1
           fi
 

--- a/.github/workflows/stable-release-discord-rtt.yml
+++ b/.github/workflows/stable-release-discord-rtt.yml
@@ -170,9 +170,11 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          version="$(node -p "require('./package.json').version")"
-          if [[ "$version" != "${{ matrix.package.version }}" ]]; then
-            echo "OpenClaw package version mismatch: expected ${{ matrix.package.version }}, got ${version}" >&2
+          tag_ref="refs/tags/${{ matrix.package.tag }}"
+          head_commit="$(git rev-parse HEAD)"
+          tag_commit="$(git rev-parse --verify "${tag_ref}^{commit}")"
+          if [[ "$head_commit" != "$tag_commit" ]]; then
+            echo "OpenClaw release ref mismatch: HEAD ${head_commit} does not match ${tag_ref} (${tag_commit})" >&2
             exit 1
           fi
 

--- a/README.md
+++ b/README.md
@@ -69,13 +69,13 @@ Use this as release coverage and regression signal, not a channel speed ranking.
 
 <!-- release-coverage:start -->
 
-Latest imported release coverage run: `2026-09-02T06:57:33.069Z`
+Latest imported release coverage run: `2026-09-03T04:16:26.562Z`
 
 | Version | p50 σ | Telegram | Discord | Slack | WhatsApp | RPC | Control UI |
 |---|---:|---:|---:|---:|---:|---:|---:|
 | `2026.9.1-beta.1` | `333ms` | `999ms` | - | fail | fail | - | `334ms` |
 | `2026.8.2` | `398ms` | `1,002ms` | - | fail | fail | - | `207ms` |
-| `2026.8.1` | `371ms` | `1,001ms` | - | fail | fail | - | `260ms` |
+| `2026.8.1` | `371ms` | `1,001ms` | fail | fail | fail | - | `260ms` |
 | `2026.8.1-beta.3` | `397ms` | `1,016ms` | - | fail | fail | - | `222ms` |
 | `2026.8.1-beta.2` | `414ms` | `1,022ms` | - | fail | fail | - | `194ms` |
 | `2026.8.1-beta.1` | `411ms` | `1,023ms` | - | fail | fail | - | `201ms` |
@@ -402,7 +402,7 @@ Discord release runs use the OpenClaw Discord QA harness with `mock-openai`, sce
 |---|---:|---:|---:|---:|---|
 | `2026.9.1-beta.1` | - | - | - | - | missing: no imported run |
 | `2026.8.2` | - | - | - | - | missing: no imported run |
-| `2026.8.1` | - | - | - | - | missing: no imported run |
+| `2026.8.1` | - | - | `5,099MB` | `5,099MB` | failed |
 | `2026.8.1-beta.3` | - | - | - | - | missing: no imported run |
 | `2026.8.1-beta.2` | - | - | - | - | missing: no imported run |
 | `2026.8.1-beta.1` | - | - | - | - | missing: no imported run |

--- a/scripts/release-workflow-contract.test.mjs
+++ b/scripts/release-workflow-contract.test.mjs
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import test from "node:test";
+
+const workflowsDir = new URL("../.github/workflows/", import.meta.url);
+const releaseWorkflows = [
+  "release-surface-rtt.yml",
+  "release-channel-rtt.yml",
+  "stable-release-discord-rtt.yml",
+];
+
+function extractStep(workflow, stepName) {
+  const marker = `      - name: ${stepName}\n`;
+  const step = workflow.split(marker)[1]?.split("\n      - name: ")[0];
+  assert.ok(step, `expected workflow step: ${stepName}`);
+  return step;
+}
+
+test("historical surface Chromium install uses the release dependency", async () => {
+  const workflow = await fs.readFile(new URL("release-surface-rtt.yml", workflowsDir), "utf8");
+  const step = extractStep(workflow, "Install Playwright Chromium");
+
+  assert.match(step, /\bworking-directory:\s*openclaw\b/u);
+  assert.match(step, /\bpnpm exec playwright-core install chromium\b/u);
+  assert.doesNotMatch(step, /\|\|/u);
+  assert.doesNotMatch(step, /\b(?:scripts\/|ensure-playwright-chromium)\b/u);
+});
+
+for (const filename of releaseWorkflows) {
+  test(`${filename}: verifies the exact release tag commit`, async () => {
+    const workflow = await fs.readFile(new URL(filename, workflowsDir), "utf8");
+    const step = extractStep(workflow, "Verify OpenClaw release ref");
+
+    assert.match(step, /tag_ref="refs\/tags\/\$\{\{ matrix\.package\.tag \}\}"/u);
+    assert.match(step, /git rev-parse HEAD/u);
+    assert.match(step, /git rev-parse --verify "\$\{tag_ref\}\^\{commit\}"/u);
+    assert.match(
+      step,
+      /if \[\[ "\$head_commit" != "\$tag_commit" \]\]; then\n\s+echo "OpenClaw release ref mismatch: HEAD \$\{head_commit\} does not match \$\{tag_ref\} \(\$\{tag_commit\}\)" >&2\n\s+exit 1\n\s+fi/u,
+    );
+    assert.doesNotMatch(step, /package\.json/u);
+    assert.doesNotMatch(step, /matrix\.package\.version/u);
+    assert.doesNotMatch(step, /\|\||\bgit describe\b/u);
+    assert.doesNotMatch(step, /\b(?:sed|awk|cut|tr)\b/u);
+    assert.doesNotMatch(step, /\$\{[^}\n]*(?:%%?|##?|:-)[^}\n]*\}/u);
+    assert.doesNotMatch(step, /tag_commit=.*(?:\$head_commit|\$\{head_commit\})/u);
+  });
+}


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where historical correction releases such as `2026.7.1-1` stopped before measurement because the RTT workflows depended on a newer OpenClaw Playwright helper and required the Git checkout's base manifest version to equal the corrected npm package version.

## Why This Change Was Made

Historical Surface measurements now install Chromium through the checked-out release's direct `playwright-core` dependency. Surface, Channel, and Discord release workflows verify that `HEAD` resolves to the requested exact tag commit instead of comparing unrelated repository and npm version surfaces.

No suffix normalization, release backport, or compatibility fallback is added.

## User Impact

Correction releases can reach their actual build and RTT scenarios. Failures after setup now represent real historical compatibility or runtime behavior instead of harness assumptions.

## Evidence

Live failures after the pnpm startup fix proved both defects:

- Surface dependency installation succeeded, then the absent release helper failed: https://github.com/openclaw/openclaw-rtt/actions/runs/33713160826
- Channel dependency installation succeeded, then `2026.7.1-1` was rejected because the tagged repository manifest is `2026.7.1`: https://github.com/openclaw/openclaw-rtt/actions/runs/33713161028
- Discord reproduced the same correction-version assertion: https://github.com/openclaw/openclaw-rtt/actions/runs/33713161538

Local validation:

- `node --test scripts/*.test.mjs`: 98/98 passing
- `actionlint` on all three changed workflows
- `node --check scripts/release-workflow-contract.test.mjs`
- `git diff --check`
- README regeneration unchanged
