### PR TITLE
fix(ci): commit RTT dashboards atomically

### DIFF
--- a/.github/workflows/main-channel-rtt.yml
+++ b/.github/workflows/main-channel-rtt.yml
@@ -405,6 +405,7 @@ jobs:
               --provider-mode mock-openai \
               --scenario "$scenario"
           done
+          node scripts/update-readme.mjs --latest-main-only
           node scripts/validate.mjs
           node scripts/channel-rtt-summary.mjs
 
@@ -413,7 +414,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          git add data/channels/ runs/
+          git add data/channels/ runs/ README.md
           if git diff --cached --quiet --exit-code; then
             echo "No channel RTT changes to commit."
             exit 0
@@ -422,6 +423,17 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git commit -m "data: record main channel rtt"
           git push || {
+            # Drop only generated dashboard state so real data conflicts still fail the rebase.
+            git restore --source=HEAD^ --staged --worktree README.md
+            git commit --amend --no-edit
             git pull --rebase origin main
+            if [[ "$(git rev-list --count "origin/main..HEAD")" == "0" ]]; then
+              echo "Channel RTT import is already present after rebase."
+              exit 0
+            fi
+            node scripts/update-readme.mjs --latest-main-only
+            node scripts/validate.mjs
+            git add README.md
+            git commit --amend --no-edit
             git push
           }

--- a/.github/workflows/main-discord-rtt.yml
+++ b/.github/workflows/main-discord-rtt.yml
@@ -189,6 +189,7 @@ jobs:
             --spec openclaw@main \
             --version "${{ steps.openclaw_ref.outputs.version }}" \
             --provider-mode mock-openai
+          node scripts/update-readme.mjs --latest-main-only
           node scripts/validate.mjs
           node scripts/discord-rtt-summary.mjs
 
@@ -206,7 +207,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          git add data/channels/discord/ runs/discord/
+          git add data/channels/discord/ runs/discord/ README.md
           if git diff --cached --quiet --exit-code; then
             echo "No Discord RTT changes to commit."
             exit 0
@@ -215,6 +216,17 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git commit -m "data: record main discord rtt"
           git push || {
+            # Drop only generated dashboard state so real data conflicts still fail the rebase.
+            git restore --source=HEAD^ --staged --worktree README.md
+            git commit --amend --no-edit
             git pull --rebase origin main
+            if [[ "$(git rev-list --count "origin/main..HEAD")" == "0" ]]; then
+              echo "Discord RTT import is already present after rebase."
+              exit 0
+            fi
+            node scripts/update-readme.mjs --latest-main-only
+            node scripts/validate.mjs
+            git add README.md
+            git commit --amend --no-edit
             git push
           }

--- a/.github/workflows/main-rtt.yml
+++ b/.github/workflows/main-rtt.yml
@@ -214,6 +214,7 @@ jobs:
             --started-at "${{ steps.rtt.outputs.started_at }}" \
             --finished-at "${{ steps.rtt.outputs.finished_at }}" \
             --resource-metrics "${{ steps.rtt.outputs.resource_metrics_path }}"
+          node scripts/update-readme.mjs --latest-main-only
           node scripts/validate.mjs
           node scripts/summary.mjs
 
@@ -223,7 +224,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          git add data/channels/telegram/ runs/telegram/
+          git add data/channels/telegram/ runs/telegram/ README.md
           if git diff --cached --quiet --exit-code; then
             echo "No RTT changes to commit."
             exit 0
@@ -232,6 +233,17 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git commit -m "data: record main rtt"
           git push || {
+            # Drop only generated dashboard state so real data conflicts still fail the rebase.
+            git restore --source=HEAD^ --staged --worktree README.md
+            git commit --amend --no-edit
             git pull --rebase origin main
+            if [[ "$(git rev-list --count "origin/main..HEAD")" == "0" ]]; then
+              echo "Telegram RTT import is already present after rebase."
+              exit 0
+            fi
+            node scripts/update-readme.mjs --latest-main-only
+            node scripts/validate.mjs
+            git add README.md
+            git commit --amend --no-edit
             git push
           }

--- a/.github/workflows/release-channel-rtt.yml
+++ b/.github/workflows/release-channel-rtt.yml
@@ -473,6 +473,17 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git commit -m "data: record channel release rtt"
           git push || {
+            # Drop only generated dashboard state so real data conflicts still fail the rebase.
+            git restore --source=HEAD^ --staged --worktree README.md
+            git commit --amend --no-edit
             git pull --rebase origin "${GITHUB_REF_NAME:-main}"
+            if [[ "$(git rev-list --count "origin/${GITHUB_REF_NAME:-main}..HEAD")" == "0" ]]; then
+              echo "Channel release RTT import is already present after rebase."
+              exit 0
+            fi
+            node scripts/update-readme.mjs
+            node scripts/validate.mjs
+            git add README.md
+            git commit --amend --no-edit
             git push
           }

--- a/.github/workflows/release-surface-rtt.yml
+++ b/.github/workflows/release-surface-rtt.yml
@@ -323,6 +323,17 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git commit -m "data: record surface release rtt"
           git push || {
+            # Drop only generated dashboard state so real data conflicts still fail the rebase.
+            git restore --source=HEAD^ --staged --worktree README.md
+            git commit --amend --no-edit
             git pull --rebase origin "${GITHUB_REF_NAME:-main}"
+            if [[ "$(git rev-list --count "origin/${GITHUB_REF_NAME:-main}..HEAD")" == "0" ]]; then
+              echo "Surface release RTT import is already present after rebase."
+              exit 0
+            fi
+            node scripts/update-readme.mjs
+            node scripts/validate.mjs
+            git add README.md
+            git commit --amend --no-edit
             git push
           }

--- a/.github/workflows/stable-release-discord-rtt.yml
+++ b/.github/workflows/stable-release-discord-rtt.yml
@@ -400,6 +400,7 @@ jobs:
                 --provider-mode mock-openai
             fi
           done
+          node scripts/update-readme.mjs
           node scripts/validate.mjs
           node scripts/discord-rtt-summary.mjs
 
@@ -407,7 +408,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          git add data/channels/discord/ runs/discord/
+          git add data/channels/discord/ runs/discord/ README.md
           if git diff --cached --quiet --exit-code; then
             echo "No Discord release RTT changes to commit."
             exit 0
@@ -416,6 +417,17 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git commit -m "data: record discord release rtt"
           git push || {
+            # Drop only generated dashboard state so real data conflicts still fail the rebase.
+            git restore --source=HEAD^ --staged --worktree README.md
+            git commit --amend --no-edit
             git pull --rebase origin "${GITHUB_REF_NAME:-main}"
+            if [[ "$(git rev-list --count "origin/${GITHUB_REF_NAME:-main}..HEAD")" == "0" ]]; then
+              echo "Discord release RTT import is already present after rebase."
+              exit 0
+            fi
+            node scripts/update-readme.mjs
+            node scripts/validate.mjs
+            git add README.md
+            git commit --amend --no-edit
             git push
           }

--- a/.github/workflows/stable-release-rtt.yml
+++ b/.github/workflows/stable-release-rtt.yml
@@ -184,8 +184,9 @@ jobs:
                 --spec "$spec" \
                 --version "$version" \
                 --resource-metrics "$metrics_path"
+              node scripts/update-readme.mjs
               node scripts/validate.mjs
-              git add data/channels/telegram/ runs/telegram/
+              git add data/channels/telegram/ runs/telegram/ README.md
               if git diff --cached --quiet --exit-code; then
                 echo "No RSS changes to commit for $spec."
                 exit 0
@@ -194,7 +195,18 @@ jobs:
               git config user.email "github-actions[bot]@users.noreply.github.com"
               git commit -m "data: record release rtt batch"
               git push || {
+                # Drop only generated dashboard state so real data conflicts still fail the rebase.
+                git restore --source=HEAD^ --staged --worktree README.md
+                git commit --amend --no-edit
                 git pull --rebase origin "${GITHUB_REF_NAME:-main}"
+                if [[ "$(git rev-list --count "origin/${GITHUB_REF_NAME:-main}..HEAD")" == "0" ]]; then
+                  echo "Telegram RSS import is already present after rebase."
+                  exit 0
+                fi
+                node scripts/update-readme.mjs
+                node scripts/validate.mjs
+                git add README.md
+                git commit --amend --no-edit
                 git push
               }
             )
@@ -283,6 +295,7 @@ jobs:
               --finished-at "$finished_at" \
               --resource-metrics "$metrics_path"
           done <"${{ steps.rtt.outputs.result_paths }}"
+          node scripts/update-readme.mjs
           node scripts/validate.mjs
           node scripts/summary.mjs
 
@@ -292,7 +305,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          git add data/channels/telegram/ runs/telegram/
+          git add data/channels/telegram/ runs/telegram/ README.md
           if git diff --cached --quiet --exit-code; then
             echo "No RTT changes to commit."
             exit 0
@@ -301,7 +314,18 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git commit -m "data: record release rtt batch"
           git push || {
+            # Drop only generated dashboard state so real data conflicts still fail the rebase.
+            git restore --source=HEAD^ --staged --worktree README.md
+            git commit --amend --no-edit
             git pull --rebase origin "${GITHUB_REF_NAME:-main}"
+            if [[ "$(git rev-list --count "origin/${GITHUB_REF_NAME:-main}..HEAD")" == "0" ]]; then
+              echo "Telegram release RTT import is already present after rebase."
+              exit 0
+            fi
+            node scripts/update-readme.mjs
+            node scripts/validate.mjs
+            git add README.md
+            git commit --amend --no-edit
             git push
           }
 

--- a/scripts/data-import-readme-workflow.test.mjs
+++ b/scripts/data-import-readme-workflow.test.mjs
@@ -1,0 +1,197 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+const IMPORT_PATHS = [
+  {
+    name: "main Telegram",
+    workflow: ".github/workflows/main-rtt.yml",
+    importStep: "Import result",
+    commitStep: "Commit result",
+    mode: "main",
+    stage: "git add data/channels/telegram/ runs/telegram/ README.md",
+    pull: "git pull --rebase origin main",
+    upstreamGuard: 'git rev-list --count "origin/main..HEAD"',
+    retry: true,
+  },
+  {
+    name: "main Discord",
+    workflow: ".github/workflows/main-discord-rtt.yml",
+    importStep: "Import Discord RTT result",
+    commitStep: "Commit result",
+    mode: "main",
+    stage: "git add data/channels/discord/ runs/discord/ README.md",
+    pull: "git pull --rebase origin main",
+    upstreamGuard: 'git rev-list --count "origin/main..HEAD"',
+    retry: true,
+  },
+  {
+    name: "main channel",
+    workflow: ".github/workflows/main-channel-rtt.yml",
+    importStep: "Import channel RTT results",
+    commitStep: "Commit result",
+    mode: "main",
+    stage: "git add data/channels/ runs/ README.md",
+    pull: "git pull --rebase origin main",
+    upstreamGuard: 'git rev-list --count "origin/main..HEAD"',
+    retry: true,
+  },
+  {
+    name: "main surface",
+    workflow: ".github/workflows/main-surface-rtt.yml",
+    importStep: "Update Surface Dashboard",
+    commitStep: "Commit imported Surface RTT",
+    mode: "main",
+    stage: "git add data/surfaces runs/surfaces README.md",
+    retry: false,
+  },
+  {
+    name: "release Telegram RSS backfill",
+    workflow: ".github/workflows/stable-release-rtt.yml",
+    importStep: "Run RSS backfill",
+    commitStep: "Run RSS backfill",
+    mode: "release",
+    stage: "git add data/channels/telegram/ runs/telegram/ README.md",
+    pull: 'git pull --rebase origin "${GITHUB_REF_NAME:-main}"',
+    upstreamGuard: 'git rev-list --count "origin/${GITHUB_REF_NAME:-main}..HEAD"',
+    retry: true,
+  },
+  {
+    name: "release Telegram",
+    workflow: ".github/workflows/stable-release-rtt.yml",
+    importStep: "Import result",
+    commitStep: "Commit result",
+    mode: "release",
+    stage: "git add data/channels/telegram/ runs/telegram/ README.md",
+    pull: 'git pull --rebase origin "${GITHUB_REF_NAME:-main}"',
+    upstreamGuard: 'git rev-list --count "origin/${GITHUB_REF_NAME:-main}..HEAD"',
+    retry: true,
+  },
+  {
+    name: "release Discord",
+    workflow: ".github/workflows/stable-release-discord-rtt.yml",
+    importStep: "Import Discord release RTT results",
+    commitStep: "Commit result",
+    mode: "release",
+    stage: "git add data/channels/discord/ runs/discord/ README.md",
+    pull: 'git pull --rebase origin "${GITHUB_REF_NAME:-main}"',
+    upstreamGuard: 'git rev-list --count "origin/${GITHUB_REF_NAME:-main}..HEAD"',
+    retry: true,
+  },
+  {
+    name: "release channel",
+    workflow: ".github/workflows/release-channel-rtt.yml",
+    importStep: "Import channel release RTT results",
+    commitStep: "Commit result",
+    mode: "release",
+    stage: "git add data/channels/ data/surfaces/ runs/ README.md",
+    pull: 'git pull --rebase origin "${GITHUB_REF_NAME:-main}"',
+    upstreamGuard: 'git rev-list --count "origin/${GITHUB_REF_NAME:-main}..HEAD"',
+    retry: true,
+  },
+  {
+    name: "release surface",
+    workflow: ".github/workflows/release-surface-rtt.yml",
+    importStep: "Import surface release RTT results",
+    commitStep: "Commit result",
+    mode: "release",
+    stage: "git add data/surfaces/ runs/surfaces/ README.md",
+    pull: 'git pull --rebase origin "${GITHUB_REF_NAME:-main}"',
+    upstreamGuard: 'git rev-list --count "origin/${GITHUB_REF_NAME:-main}..HEAD"',
+    retry: true,
+  },
+];
+
+function extractStep(workflow, name) {
+  const marker = `      - name: ${name}\n`;
+  const start = workflow.indexOf(marker);
+  assert.notEqual(start, -1, `missing workflow step: ${name}`);
+  const next = workflow.indexOf("\n      - name:", start + marker.length);
+  return workflow.slice(start, next === -1 ? workflow.length : next);
+}
+
+function extractRetry(step) {
+  const start = step.indexOf("git push || {");
+  assert.notEqual(start, -1, "missing push retry block");
+  const lines = step.slice(start).split("\n");
+  const end = lines.findIndex((line, index) => index > 0 && line.trim() === "}");
+  assert.notEqual(end, -1, "unterminated push retry block");
+  return lines.slice(1, end).join("\n");
+}
+
+function assertOrdered(contents, commands, context) {
+  let offset = 0;
+  for (const command of commands) {
+    const index = contents.indexOf(command, offset);
+    assert.notEqual(index, -1, `${context}: missing or out-of-order command: ${command}`);
+    offset = index + command.length;
+  }
+}
+
+function readmeCommand(mode) {
+  return mode === "main"
+    ? "node scripts/update-readme.mjs --latest-main-only"
+    : "node scripts/update-readme.mjs";
+}
+
+test("all nine data import paths update README atomically", async (t) => {
+  assert.equal(IMPORT_PATHS.length, 9);
+  const workflowCache = new Map();
+
+  for (const pathConfig of IMPORT_PATHS) {
+    await t.test(pathConfig.name, async () => {
+      let workflow = workflowCache.get(pathConfig.workflow);
+      if (!workflow) {
+        workflow = await fs.readFile(path.join(REPO_ROOT, pathConfig.workflow), "utf8");
+        workflowCache.set(pathConfig.workflow, workflow);
+      }
+
+      const generation = readmeCommand(pathConfig.mode);
+      const importStep = extractStep(workflow, pathConfig.importStep);
+      const commitStep = extractStep(workflow, pathConfig.commitStep);
+
+      assertOrdered(
+        importStep,
+        [generation, "node scripts/validate.mjs"],
+        `${pathConfig.name} initial import`,
+      );
+      assert.match(
+        commitStep,
+        new RegExp(`^\\s*${pathConfig.stage.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&")}$`, "mu"),
+        `${pathConfig.name} must stage README.md with imported data`,
+      );
+
+      const generationLine = importStep
+        .split("\n")
+        .find((line) => line.trim().startsWith("node scripts/update-readme.mjs"));
+      assert.equal(generationLine?.trim(), generation, `${pathConfig.name} uses the wrong README mode`);
+
+      if (!pathConfig.retry) {
+        assert.doesNotMatch(commitStep, /git push \|\| \{/u);
+        return;
+      }
+
+      const retry = extractRetry(commitStep);
+      assertOrdered(
+        retry,
+        [
+          "git restore --source=HEAD^ --staged --worktree README.md",
+          "git commit --amend --no-edit",
+          pathConfig.pull,
+          pathConfig.upstreamGuard,
+          "exit 0",
+          generation,
+          "node scripts/validate.mjs",
+          "git add README.md",
+          "git commit --amend --no-edit",
+          "git push",
+        ],
+        `${pathConfig.name} push retry`,
+      );
+    });
+  }
+});


### PR DESCRIPTION
## Problem

RTT import workflows wrote measurement data in one commit and refreshed the generated dashboard later through asynchronous hydration. A failed or racing hydration run could leave `README.md` stale even though the underlying data had landed.

Push retries also rebased commits containing a generated README, so concurrent imports could conflict on dashboard output instead of regenerating it from the rebased data.

## Change

- Generate and validate the correct dashboard view inside every main and release import path.
- Stage `README.md` with the measurement data so each import commit is self-consistent.
- Before retrying a rejected push, remove only the unpublished generated README from the commit, rebase the real data, regenerate, validate, and amend.
- Add a contract test covering all nine import paths, main/release modes, staging, and retry ordering.

Main Surface already followed the complete atomic pattern and remains unchanged.

## Evidence

- `node --test scripts/data-import-readme-workflow.test.mjs scripts/update-readme.test.mjs`: 19/19 passing
- `node --test scripts/*.test.mjs`: 108/108 passing
- `npm run check`: 4,241 rows validated
- `actionlint` on all seven touched workflows
- `node --check scripts/data-import-readme-workflow.test.mjs`
- `git diff --check`
- Fresh structured autoreview: clean after fixing the lost-push-acknowledgement retry case

## Operational Impact

Data-file conflicts still fail normally. Only generated dashboard state is discarded before a retry, then rebuilt from the rebased canonical data.
