### PR TITLE
fix: historical Discord RTT fails with current QA config

### DIFF
--- a/scripts/release-qa-config-compat.mjs
+++ b/scripts/release-qa-config-compat.mjs
@@ -36,6 +36,10 @@ function compareVersions(left, right) {
   return 0;
 }
 
+function isRecord(value) {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
 export function resolveReleaseAuthRuntimePath(packageSpec, runtimePath) {
   return parseExactPackageVersion(packageSpec) && typeof runtimePath === "string" && runtimePath.trim()
     ? runtimePath
@@ -47,51 +51,149 @@ export async function resolveReleaseAuthRuntime(packageSpec, runtimePath) {
   return resolvedPath ? await import(pathToFileURL(resolvedPath).href) : undefined;
 }
 
-function legacyMemoryConfig(memory) {
-  if (!memory || typeof memory !== "object" || Array.isArray(memory)) {
+function legacyMemoryConfig(memory, moveSearchToAgentDefaults) {
+  if (!isRecord(memory) || !moveSearchToAgentDefaults) {
     return memory;
   }
-  return Object.fromEntries(
-    ["backend", "citations", "qmd"]
-      .filter((key) => memory[key] !== undefined)
-      .map((key) => [key, memory[key]]),
-  );
+  const { search: _search, ...legacyMemory } = memory;
+  return legacyMemory;
 }
 
-function legacyAgentsConfig(agents) {
-  if (!agents || typeof agents !== "object" || Array.isArray(agents)) {
+function legacyAgentDefaults(defaults, memorySearch) {
+  if (defaults === undefined) {
+    return memorySearch === undefined ? undefined : { memorySearch };
+  }
+  if (!isRecord(defaults)) {
+    return defaults;
+  }
+
+  const { mediaModels, modelPolicy, ...legacyDefaults } = defaults;
+  const adaptedDefaults = {
+    ...legacyDefaults,
+    ...(!isRecord(modelPolicy) && modelPolicy !== undefined ? { modelPolicy } : {}),
+    ...(memorySearch === undefined ? {} : { memorySearch }),
+  };
+  if (!isRecord(mediaModels)) {
+    return mediaModels === undefined
+      ? adaptedDefaults
+      : {
+          ...adaptedDefaults,
+          mediaModels,
+        };
+  }
+
+  const { image, video, music, ...unknownMediaModels } = mediaModels;
+  return {
+    ...adaptedDefaults,
+    ...(image === undefined ? {} : { imageGenerationModel: image }),
+    ...(video === undefined ? {} : { videoGenerationModel: video }),
+    ...(music === undefined ? {} : { musicGenerationModel: music }),
+    ...(Object.keys(unknownMediaModels).length === 0
+      ? {}
+      : { mediaModels: unknownMediaModels }),
+  };
+}
+
+function legacyAgentEntry(entry) {
+  const { memory, modelPolicy, ...legacyEntry } = entry;
+  const adaptedEntry = {
+    ...legacyEntry,
+    ...(!isRecord(modelPolicy) && modelPolicy !== undefined ? { modelPolicy } : {}),
+  };
+  if (!isRecord(memory)) {
+    return memory === undefined ? adaptedEntry : { ...adaptedEntry, memory };
+  }
+  if (!Object.hasOwn(memory, "search")) {
+    return { ...adaptedEntry, memory };
+  }
+
+  const { search, ...unknownMemory } = memory;
+  return {
+    ...adaptedEntry,
+    ...(search === undefined ? {} : { memorySearch: search }),
+    ...(Object.keys(unknownMemory).length === 0 ? {} : { memory: unknownMemory }),
+  };
+}
+
+function legacyAgentsConfig(agents, memorySearch) {
+  if (agents === undefined) {
+    return memorySearch === undefined ? undefined : { defaults: { memorySearch } };
+  }
+  if (!isRecord(agents)) {
     return agents;
   }
-  const { entries, ...legacyAgents } = agents;
-  if (!entries || typeof entries !== "object" || Array.isArray(entries)) {
-    return legacyAgents;
+
+  const defaults = legacyAgentDefaults(agents.defaults, memorySearch);
+  const withLegacyDefaults = {
+    ...agents,
+    ...(defaults === undefined ? {} : { defaults }),
+  };
+  if (!isRecord(agents.entries)) {
+    return withLegacyDefaults;
   }
+  const entries = Object.entries(agents.entries);
+  if (entries.some(([, entry]) => !isRecord(entry))) {
+    return withLegacyDefaults;
+  }
+
+  const { entries: _entries, ...legacyAgents } = withLegacyDefaults;
   return {
     ...legacyAgents,
-    list: Object.entries(entries).map(([id, entry]) => ({
-      ...(entry && typeof entry === "object" && !Array.isArray(entry) ? entry : {}),
+    list: entries.map(([id, entry]) => ({
+      ...legacyAgentEntry(entry),
       id,
     })),
   };
 }
 
-export function adaptReleaseGatewayConfig(config, packageSpec) {
-  const candidateVersion = parseExactPackageVersion(packageSpec);
-  if (!candidateVersion) {
+function legacyReleaseConfig(config) {
+  const memorySearch =
+    isRecord(config.memory) && Object.hasOwn(config.memory, "search")
+      ? config.memory.search
+      : undefined;
+  const moveSearchToAgentDefaults =
+    memorySearch !== undefined &&
+    (config.agents === undefined ||
+      (isRecord(config.agents) &&
+        (config.agents.defaults === undefined || isRecord(config.agents.defaults))));
+  const agents = legacyAgentsConfig(
+    config.agents,
+    moveSearchToAgentDefaults ? memorySearch : undefined,
+  );
+  const memory = legacyMemoryConfig(config.memory, moveSearchToAgentDefaults);
+
+  const synthesizeAgents = !Object.hasOwn(config, "agents") && agents !== undefined;
+  if (!Object.hasOwn(config, "agents") && !Object.hasOwn(config, "memory") && !synthesizeAgents) {
     return config;
   }
-  const legacyConfig = compareVersions(candidateVersion, LEGACY_CONFIG_CUTOFF) < 0;
+  return {
+    ...config,
+    ...(Object.hasOwn(config, "agents") || synthesizeAgents ? { agents } : {}),
+    ...(Object.hasOwn(config, "memory") ? { memory } : {}),
+  };
+}
+
+function stampCandidateVersion(config, version) {
+  if (!isRecord(config)) {
+    return config;
+  }
   return {
     ...config,
     meta: {
-      ...config.meta,
-      lastTouchedVersion: candidateVersion.version,
+      ...(isRecord(config.meta) ? config.meta : {}),
+      lastTouchedVersion: version,
     },
-    ...(legacyConfig
-      ? {
-          agents: legacyAgentsConfig(config.agents),
-          memory: legacyMemoryConfig(config.memory),
-        }
-      : {}),
   };
+}
+
+export function adaptReleaseGatewayConfig(config, packageSpec) {
+  const candidateVersion = parseExactPackageVersion(packageSpec);
+  if (!candidateVersion || !isRecord(config)) {
+    return config;
+  }
+  const legacyConfig = compareVersions(candidateVersion, LEGACY_CONFIG_CUTOFF) < 0;
+  return stampCandidateVersion(
+    legacyConfig ? legacyReleaseConfig(config) : config,
+    candidateVersion.version,
+  );
 }

--- a/scripts/release-qa-config-compat.test.mjs
+++ b/scripts/release-qa-config-compat.test.mjs
@@ -10,18 +10,51 @@ function currentConfig() {
   return {
     meta: { lastTouchedVersion: "2026.7.2" },
     agents: {
-      defaults: { workspace: "/tmp/qa" },
+      defaults: {
+        workspace: "/tmp/qa",
+        model: "mock-openai/qa",
+        models: {
+          "mock-openai/qa": {},
+          "mock-openai/qa-fast": {},
+        },
+        modelPolicy: {
+          allow: ["mock-openai/qa", "mock-openai/qa-fast"],
+        },
+        mediaModels: {
+          image: {
+            primary: "mock-openai/qa-image",
+          },
+        },
+        subagents: {
+          allowAgents: ["*"],
+          maxConcurrent: 2,
+        },
+      },
       entries: {
         qa: {
-          default: true,
           model: "mock-openai/qa",
+          identity: {
+            name: "C-3PO QA",
+          },
         },
       },
     },
     memory: {
-      backend: "builtin",
       search: {
-        enabled: false,
+        provider: "openai-compatible",
+        model: "text-embedding-3-small",
+        remote: {
+          baseUrl: "http://127.0.0.1:12345/v1",
+          apiKey: "test",
+        },
+      },
+    },
+    models: {
+      providers: {
+        "openai-compatible": {
+          api: "openai-responses",
+          baseUrl: "http://127.0.0.1:12345/v1",
+        },
       },
     },
     plugins: {
@@ -30,63 +63,243 @@ function currentConfig() {
   };
 }
 
-test("adapts legacy release config and stamps the candidate version", () => {
+test("projects the current Discord QA config into the legacy release shape", () => {
   const config = currentConfig();
-  const adapted = adaptReleaseGatewayConfig(config, "openclaw@2026.6.33");
+  const adapted = adaptReleaseGatewayConfig(config, "openclaw@2026.7.1-1");
 
   assert.notStrictEqual(adapted, config);
-  assert.deepEqual(adapted.meta, { lastTouchedVersion: "2026.6.33" });
+  assert.deepEqual(adapted.meta, { lastTouchedVersion: "2026.7.1-1" });
   assert.deepEqual(adapted.agents, {
-    defaults: { workspace: "/tmp/qa" },
+    defaults: {
+      workspace: "/tmp/qa",
+      model: "mock-openai/qa",
+      models: {
+        "mock-openai/qa": {},
+        "mock-openai/qa-fast": {},
+      },
+      imageGenerationModel: {
+        primary: "mock-openai/qa-image",
+      },
+      memorySearch: {
+        provider: "openai-compatible",
+        model: "text-embedding-3-small",
+        remote: {
+          baseUrl: "http://127.0.0.1:12345/v1",
+          apiKey: "test",
+        },
+      },
+      subagents: {
+        allowAgents: ["*"],
+        maxConcurrent: 2,
+      },
+    },
     list: [
       {
-        default: true,
         id: "qa",
         model: "mock-openai/qa",
+        identity: {
+          name: "C-3PO QA",
+        },
       },
     ],
   });
-  assert.deepEqual(adapted.memory, { backend: "builtin" });
+  assert.deepEqual(adapted.memory, {});
+  assert.equal(
+    adapted.models.providers["openai-compatible"],
+    config.models.providers["openai-compatible"],
+  );
   assert.deepEqual(adapted.plugins, config.plugins);
   assert.deepEqual(config, currentConfig());
 });
 
-test("preserves current config shape while stamping beta releases", () => {
-  const config = currentConfig();
-  const adapted = adaptReleaseGatewayConfig(config, "openclaw@2026.7.2-beta.4");
+test("uses the beta.4 boundary for legacy config projection", () => {
+  for (const packageSpec of ["openclaw@2026.7.1-1", "openclaw@2026.7.2-beta.3"]) {
+    const adapted = adaptReleaseGatewayConfig(currentConfig(), packageSpec);
+    assert.ok(adapted.agents.list, packageSpec);
+    assert.equal(adapted.agents.entries, undefined, packageSpec);
+    assert.equal(adapted.agents.defaults.modelPolicy, undefined, packageSpec);
+    assert.equal(adapted.agents.defaults.mediaModels, undefined, packageSpec);
+    assert.ok(adapted.agents.defaults.memorySearch, packageSpec);
+    assert.equal(adapted.memory.search, undefined, packageSpec);
+  }
 
-  assert.deepEqual(adapted, {
-    ...config,
-    meta: { lastTouchedVersion: "2026.7.2-beta.4" },
-  });
-});
-
-test("adapts historical numeric post releases before the config cutoff", () => {
-  const config = currentConfig();
-  const adapted = adaptReleaseGatewayConfig(config, "openclaw@2026.7.1-2");
-
-  assert.deepEqual(adapted.meta, { lastTouchedVersion: "2026.7.1-2" });
-  assert.deepEqual(adapted.agents, {
-    defaults: { workspace: "/tmp/qa" },
-    list: [
+  for (const packageSpec of [
+    "openclaw@2026.7.2-beta.4",
+    "openclaw@2026.7.2",
+    "openclaw@2026.7.2-1",
+  ]) {
+    const config = currentConfig();
+    const adapted = adaptReleaseGatewayConfig(config, packageSpec);
+    assert.deepEqual(
+      adapted,
       {
-        default: true,
-        id: "qa",
-        model: "mock-openai/qa",
+        ...config,
+        meta: { lastTouchedVersion: packageSpec.slice("openclaw@".length) },
       },
-    ],
-  });
-  assert.deepEqual(adapted.memory, { backend: "builtin" });
+      packageSpec,
+    );
+  }
 });
 
-test("preserves current config shape for numeric post releases after the cutoff", () => {
-  const config = currentConfig();
-  const adapted = adaptReleaseGatewayConfig(config, "openclaw@2026.7.2-1");
+test("does not synthesize absent legacy config fields", () => {
+  const config = {
+    meta: { mode: "test" },
+    plugins: { enabled: true },
+  };
+  const adapted = adaptReleaseGatewayConfig(config, "openclaw@2026.7.1-1");
 
   assert.deepEqual(adapted, {
-    ...config,
-    meta: { lastTouchedVersion: "2026.7.2-1" },
+    meta: {
+      mode: "test",
+      lastTouchedVersion: "2026.7.1-1",
+    },
+    plugins: { enabled: true },
   });
+  assert.equal(Object.hasOwn(adapted, "agents"), false);
+  assert.equal(Object.hasOwn(adapted, "memory"), false);
+});
+
+test("maps every media model and preserves existing legacy memory settings", () => {
+  const config = currentConfig();
+  config.agents.defaults.mediaModels.video = {
+    primary: "mock-openai/qa-video",
+  };
+  config.agents.defaults.mediaModels.music = {
+    primary: "mock-openai/qa-music",
+  };
+  config.memory.backend = "builtin";
+  config.memory.citations = "auto";
+  config.memory.qmd = {
+    command: "mock-qmd",
+  };
+  const adapted = adaptReleaseGatewayConfig(config, "openclaw@2026.7.1-1");
+
+  assert.deepEqual(adapted.agents.defaults.imageGenerationModel, {
+    primary: "mock-openai/qa-image",
+  });
+  assert.deepEqual(adapted.agents.defaults.videoGenerationModel, {
+    primary: "mock-openai/qa-video",
+  });
+  assert.deepEqual(adapted.agents.defaults.musicGenerationModel, {
+    primary: "mock-openai/qa-music",
+  });
+  assert.deepEqual(adapted.memory, {
+    backend: "builtin",
+    citations: "auto",
+    qmd: {
+      command: "mock-qmd",
+    },
+  });
+});
+
+test("projects per-agent memory search and model policy into the legacy entry shape", () => {
+  const config = currentConfig();
+  config.agents.entries.qa.modelPolicy = {
+    allow: ["mock-openai/qa"],
+  };
+  config.agents.entries.qa.memory = {
+    search: {
+      provider: "openai-compatible",
+      model: "text-embedding-3-small",
+    },
+  };
+  const adapted = adaptReleaseGatewayConfig(config, "openclaw@2026.7.1-1");
+
+  assert.deepEqual(adapted.agents.list[0], {
+    id: "qa",
+    model: "mock-openai/qa",
+    identity: {
+      name: "C-3PO QA",
+    },
+    memorySearch: {
+      provider: "openai-compatible",
+      model: "text-embedding-3-small",
+    },
+  });
+});
+
+test("synthesizes the legacy memory-search owner when agents are absent", () => {
+  const config = {
+    memory: {
+      search: {
+        provider: "local",
+      },
+      backend: "builtin",
+    },
+  };
+  const adapted = adaptReleaseGatewayConfig(config, "openclaw@2026.7.1-1");
+
+  assert.deepEqual(adapted, {
+    meta: {
+      lastTouchedVersion: "2026.7.1-1",
+    },
+    agents: {
+      defaults: {
+        memorySearch: {
+          provider: "local",
+        },
+      },
+    },
+    memory: {
+      backend: "builtin",
+    },
+  });
+});
+
+test("retains unknown semantic fields for historical strict validation", () => {
+  const config = currentConfig();
+  config.agents.defaults.mediaModels.speech = {
+    primary: "mock-openai/qa-speech",
+  };
+  config.memory.experimentalSearchPolicy = {
+    mode: "future",
+  };
+  config.agents.entries.qa.memory = {
+    search: {
+      provider: "local",
+    },
+    futurePolicy: {
+      mode: "future",
+    },
+  };
+  const adapted = adaptReleaseGatewayConfig(config, "openclaw@2026.7.1-1");
+
+  assert.deepEqual(adapted.agents.defaults.mediaModels, {
+    speech: {
+      primary: "mock-openai/qa-speech",
+    },
+  });
+  assert.deepEqual(adapted.memory.experimentalSearchPolicy, {
+    mode: "future",
+  });
+  assert.deepEqual(adapted.agents.list[0].memory, {
+    futurePolicy: {
+      mode: "future",
+    },
+  });
+});
+
+test("retains malformed new-shape fields instead of silently discarding them", () => {
+  const config = currentConfig();
+  config.agents.entries = ["qa"];
+  config.agents.defaults.mediaModels = ["mock-openai/qa-image"];
+  config.agents.defaults.modelPolicy = ["mock-openai/qa"];
+  const adapted = adaptReleaseGatewayConfig(config, "openclaw@2026.7.1-1");
+
+  assert.deepEqual(adapted.agents.entries, ["qa"]);
+  assert.deepEqual(adapted.agents.defaults.mediaModels, ["mock-openai/qa-image"]);
+  assert.deepEqual(adapted.agents.defaults.modelPolicy, ["mock-openai/qa"]);
+  assert.equal(adapted.agents.list, undefined);
+});
+
+test("legacy projection is idempotent and does not mutate its input", () => {
+  const config = currentConfig();
+  const snapshot = structuredClone(config);
+  const first = adaptReleaseGatewayConfig(config, "openclaw@2026.7.1-1");
+  const second = adaptReleaseGatewayConfig(first, "openclaw@2026.7.1-1");
+
+  assert.deepEqual(config, snapshot);
+  assert.deepEqual(second, first);
 });
 
 test("selects the candidate auth runtime only for exact release specs", () => {
@@ -108,4 +321,5 @@ test("leaves non-release configs untouched", () => {
   assert.strictEqual(adaptReleaseGatewayConfig(config, "openclaw@main"), config);
   assert.strictEqual(adaptReleaseGatewayConfig(config, "openclaw@2026.7.1-rc.1"), config);
   assert.strictEqual(adaptReleaseGatewayConfig(config, undefined), config);
+  assert.strictEqual(adaptReleaseGatewayConfig(undefined, "openclaw@2026.7.1-1"), undefined);
 });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where historical Discord release RTT runs failed before sampling because the current QA harness generated config fields that older OpenClaw releases reject.

## Why This Change Was Made

Projects the current QA config into the exact historical schema used before `v2026.7.2-beta.4`. The projection is release-bounded, immutable, idempotent, preserves supported settings, and retains unknown semantic fields so strict historical validation still fails loudly.

## User Impact

Operators can replay Discord RTT measurements for affected historical releases instead of getting `agents.defaults: Invalid input` during gateway startup.

## Evidence

- Reproduced in Release Discord RTT run `33714698943` for `openclaw@2026.7.1-1`.
- `node --test scripts/release-qa-config-compat.test.mjs scripts/patch-openclaw-release-qa-harness.test.mjs`: 13 passed.
- `node --test scripts/*.test.mjs`: 113 passed.
- `npm run check`: passed; 4,243 RTT rows validated.
- `git diff --check`: passed.
- Structured autoreview: clean, 0.87 confidence.
