### PR TITLE
fix(ci): restore Discord release RTT timing

### DIFF
--- a/.github/workflows/stable-release-discord-rtt.yml
+++ b/.github/workflows/stable-release-discord-rtt.yml
@@ -111,7 +111,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           repository: openclaw/openclaw
-          ref: 3100ba535f1d003d67a6a7536deacf8666367b38 # OpenClaw main, 2026-09-03
+          ref: f50c6020e8f535beb6b442bbceadeae89568e6d0 # OpenClaw main, 2026-09-03
           path: openclaw-qa
           fetch-depth: 1
           persist-credentials: false

--- a/scripts/release-report-workflow.test.mjs
+++ b/scripts/release-report-workflow.test.mjs
@@ -9,7 +9,7 @@ import test from "node:test";
 const execFileAsync = promisify(execFile);
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const HELPER_PATH = path.join(REPO_ROOT, "scripts/handle-missing-release-imports.mjs");
-const OPENCLAW_QA_SHA = "3100ba535f1d003d67a6a7536deacf8666367b38";
+const OPENCLAW_QA_SHA = "f50c6020e8f535beb6b442bbceadeae89568e6d0";
 const WORKFLOWS = [
   {
     family: "surface",


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/pull/136814

## What Problem This Solves

Fixes an issue where historical Discord RTT replays could pass the live canary but be imported as failed because the pinned OpenClaw QA producer did not emit reply latency.

## Why This Change Was Made

Pins the release Discord workflow to the exact merged OpenClaw commit that records request-to-observed-message timing and updates the workflow contract test to keep that producer SHA synchronized. The RTT importer remains strict and does not treat whole-command duration as latency.

## User Impact

Discord release replays can produce measurable RTT rows again, allowing failed baseline gaps to be retried and closed with real timing evidence.

## Evidence

- Before: https://github.com/openclaw/openclaw-rtt/actions/runs/33716884974 passed `discord-canary`, but its evidence omitted `result.timing.rttMs`, so RTT imported an empty failed sample.
- Producer fix: https://github.com/openclaw/openclaw/pull/136814
- Focused Node tests: 10/10 passed.
- `npm run check`: passed.
- `actionlint`: passed.
- `git diff --check`: passed.
- Autoreview: clean at 0.99 confidence.
- TruffleHog: clean.
