### PR TITLE
fix(ci): preserve queued RTT jobs

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -7,3 +7,17 @@ self-hosted-runner:
     - openclaw-rtt
 
 config-variables: null
+
+paths:
+  .github/workflows/main-channel-rtt.yml:
+    ignore:
+      - '^unexpected key "queue" for "concurrency" section\. expected one of "cancel-in-progress", "group"$'
+  .github/workflows/release-channel-rtt.yml:
+    ignore:
+      - '^unexpected key "queue" for "concurrency" section\. expected one of "cancel-in-progress", "group"$'
+  .github/workflows/release-surface-rtt.yml:
+    ignore:
+      - '^unexpected key "queue" for "concurrency" section\. expected one of "cancel-in-progress", "group"$'
+  .github/workflows/stable-release-discord-rtt.yml:
+    ignore:
+      - '^unexpected key "queue" for "concurrency" section\. expected one of "cancel-in-progress", "group"$'

--- a/.github/workflows/main-channel-rtt.yml
+++ b/.github/workflows/main-channel-rtt.yml
@@ -93,8 +93,9 @@ jobs:
     timeout-minutes: 120
     environment: qa-live-shared
     concurrency:
-      group: channel-rtt-measure-${{ matrix.channel }}-${{ github.ref }}
-      cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+      group: channel-rtt-measure-${{ matrix.channel }}
+      cancel-in-progress: false
+      queue: max
     strategy:
       fail-fast: false
       max-parallel: 1
@@ -330,6 +331,7 @@ jobs:
     concurrency:
       group: rtt-report-writer-${{ github.event_name == 'pull_request' && github.run_id || github.ref }}
       cancel-in-progress: false
+      queue: max
     steps:
       - name: Checkout RTT tracker
         uses: actions/checkout@v7

--- a/.github/workflows/release-channel-rtt.yml
+++ b/.github/workflows/release-channel-rtt.yml
@@ -88,8 +88,9 @@ jobs:
     timeout-minutes: 120
     environment: qa-live-shared
     concurrency:
-      group: channel-rtt-measure-${{ matrix.package.channel }}-${{ github.ref }}
+      group: channel-rtt-measure-${{ matrix.package.channel }}
       cancel-in-progress: false
+      queue: max
     strategy:
       fail-fast: false
       max-parallel: 1
@@ -382,6 +383,7 @@ jobs:
     concurrency:
       group: rtt-report-writer-${{ github.ref }}
       cancel-in-progress: false
+      queue: max
     steps:
       - name: Checkout RTT tracker
         uses: actions/checkout@v7

--- a/.github/workflows/release-surface-rtt.yml
+++ b/.github/workflows/release-surface-rtt.yml
@@ -241,6 +241,7 @@ jobs:
     concurrency:
       group: rtt-report-writer-${{ github.ref }}
       cancel-in-progress: false
+      queue: max
     steps:
       - name: Checkout RTT tracker
         uses: actions/checkout@v7

--- a/.github/workflows/stable-release-discord-rtt.yml
+++ b/.github/workflows/stable-release-discord-rtt.yml
@@ -328,6 +328,7 @@ jobs:
     concurrency:
       group: rtt-report-writer-${{ github.ref }}
       cancel-in-progress: false
+      queue: max
     steps:
       - name: Checkout RTT tracker
         uses: actions/checkout@v7

--- a/scripts/channel-workflow-concurrency.test.mjs
+++ b/scripts/channel-workflow-concurrency.test.mjs
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import test from "node:test";
+
+const workflowsDir = new URL("../.github/workflows/", import.meta.url);
+
+function extractJob(workflow, jobName) {
+  const marker = `  ${jobName}:\n`;
+  const job = workflow.split(marker)[1]?.split(/\n  [a-zA-Z0-9_-]+:\n/u)[0];
+  assert.ok(job, `expected workflow job: ${jobName}`);
+  return job;
+}
+
+function extractBlock(job, blockName) {
+  const marker = `    ${blockName}:\n`;
+  const block = job.split(marker)[1]?.split(/\n    [a-zA-Z0-9_-]+:/u)[0];
+  assert.ok(block, `expected job block: ${blockName}`);
+  return block;
+}
+
+function assertLine(block, expected) {
+  assert.ok(
+    block.split("\n").includes(expected),
+    `expected exact line in block: ${expected}`,
+  );
+}
+
+const channelWorkflows = [
+  {
+    filename: "main-channel-rtt.yml",
+    measureGroup: "channel-rtt-measure-${{ matrix.channel }}",
+  },
+  {
+    filename: "release-channel-rtt.yml",
+    measureGroup: "channel-rtt-measure-${{ matrix.package.channel }}",
+  },
+];
+
+for (const { filename, measureGroup } of channelWorkflows) {
+  test(`${filename}: queues channel measurement jobs by shared channel`, async () => {
+    const workflow = await fs.readFile(new URL(filename, workflowsDir), "utf8");
+    const measure = extractJob(workflow, "measure");
+    const concurrency = extractBlock(measure, "concurrency");
+    const strategy = extractBlock(measure, "strategy");
+
+    assertLine(concurrency, `      group: ${measureGroup}`);
+    assertLine(concurrency, "      cancel-in-progress: false");
+    assertLine(concurrency, "      queue: max");
+    assert.doesNotMatch(concurrency, /github\.ref/u);
+    assertLine(strategy, "      max-parallel: 1");
+  });
+}
+
+const reportWorkflows = [
+  "main-channel-rtt.yml",
+  "release-channel-rtt.yml",
+  "release-surface-rtt.yml",
+  "stable-release-discord-rtt.yml",
+];
+
+for (const filename of reportWorkflows) {
+  test(`${filename}: queues report writer jobs without cancellation`, async () => {
+    const workflow = await fs.readFile(new URL(filename, workflowsDir), "utf8");
+    const report = extractJob(workflow, "report");
+    const concurrency = extractBlock(report, "concurrency");
+
+    assert.match(concurrency, /^\s+group: rtt-report-writer-/mu);
+    assertLine(concurrency, "      cancel-in-progress: false");
+    assertLine(concurrency, "      queue: max");
+  });
+}


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where channel release backfills with multiple versions for the same channel would silently cancel older pending matrix jobs before a runner started. The same single-pending-slot behavior could also displace RTT report writers.

Live evidence: https://github.com/openclaw/openclaw-rtt/actions/runs/33725093678

## Why This Change Was Made

GitHub concurrency groups default to one running and one pending job; a newer waiter replaces the existing pending job even when `cancel-in-progress` is false. The workflows now opt into `queue: max`, retain per-channel serialization across main and release runs, and queue shared report writers instead of evicting them. The actionlint exceptions are path-scoped to its known unsupported `queue` schema warning: https://github.com/rhysd/actionlint/issues/657

## User Impact

Operators can backfill multiple Slack or WhatsApp releases without matrix entries disappearing while they wait for shared live credentials. Concurrent report imports also remain queued instead of being replaced.

## Evidence

- Reproduced: a pending WhatsApp release job was cancelled with zero steps while a newer same-group matrix job queued.
- `node --test scripts/channel-workflow-concurrency.test.mjs`: 6/6 passed.
- `npm test`: 119/119 passed.
- `npm run check`: passed.
- `actionlint`: passed with exact path-scoped compatibility ignores.
- `git diff --check`: passed.
- Autoreview: clean, confidence 0.97.
- TruffleHog review-bundle scan: clean.
