### PR TITLE
fix(ci): stop retrying broken Discord beta

### DIFF
--- a/scripts/release-gap-reasons.mjs
+++ b/scripts/release-gap-reasons.mjs
@@ -3,6 +3,7 @@ export const DISCORD_RELEASE_PROTOCOL_GAP_REASONS = {
   "2026.5.3": "release omits Discord observed-message timing data",
   "2026.5.16-beta.5": "release does not complete the current Discord canary",
   "2026.5.16-beta.6": "release does not complete the current Discord canary",
+  "2026.8.1-beta.2": "release does not complete the current Discord canary",
 };
 
 export function discordReleaseGapReason(version) {

--- a/scripts/resolve-openclaw-discord-package.test.mjs
+++ b/scripts/resolve-openclaw-discord-package.test.mjs
@@ -190,16 +190,19 @@ test("skips proven historical Discord release gaps", async () => {
     releaseRow("2026.5.12", "telegram"),
     releaseRow("2026.5.16-beta.5", "telegram"),
     releaseRow("2026.5.16-beta.6", "telegram"),
+    releaseRow("2026.8.1-beta.2", "telegram"),
   ]);
   await writeJsonl(path.join(workspace, "data/channels/discord.jsonl"), [
     releaseRow("2026.5.12", "discord"),
     releaseRow("2026.5.16-beta.5", "discord", "fail"),
     releaseRow("2026.5.16-beta.6", "discord", "fail"),
+    releaseRow("2026.8.1-beta.2", "discord", "fail"),
   ]);
   const binDir = await writeFakeNpm(workspace, [
     "2026.5.12",
     "2026.5.16-beta.5",
     "2026.5.16-beta.6",
+    "2026.8.1-beta.2",
   ]);
 
   const { stdout } = await execFileAsync(process.execPath, [RESOLVE_SCRIPT], {
@@ -233,10 +236,10 @@ test("rejects explicit historical Discord release gaps", async () => {
       env: {
         ...process.env,
         GITHUB_OUTPUT: "",
-        INPUT_VERSIONS: "2026.5.16-beta.5",
+        INPUT_VERSIONS: "2026.8.1-beta.2",
       },
     }),
-    /known Discord release protocol gap: 2026\.5\.16-beta\.5/u,
+    /known Discord release protocol gap: 2026\.8\.1-beta\.2 \(release does not complete the current Discord canary\)/u,
   );
 });
 


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the release Discord RTT resolver repeatedly schedules the immutable `openclaw@2026.8.1-beta.2` package even though two independent runs timed out after 45 seconds without a Discord canary reply.

## Why This Change Was Made

Registers the release under the existing proven Discord protocol-gap policy and extends resolver coverage for both automatic and explicit scheduling. Existing failed evidence remains intact; this only stops repeated no-value reruns.

## User Impact

RTT backfills can finish without continually requeueing a permanently broken historical beta. The dashboard keeps showing the imported timeout evidence for that release.

## Evidence

- Initial matrix run: https://github.com/openclaw/openclaw-rtt/actions/runs/33719868314
- Isolated retry with the same timeout: https://github.com/openclaw/openclaw-rtt/actions/runs/33725094011
- Adjacent `2026.8.1-beta.1`, `2026.8.1-beta.3`, stable `2026.8.1`, and later releases passed in the matrix run.
- `node --test scripts/resolve-openclaw-discord-package.test.mjs` - 7/7 passed
- `npm test` - 119/119 passed
- `npm run check` - passed
- `git diff --check` - passed
- Fresh autoreview - clean, 0.99
