### PR TITLE
fix(ci): import historical channel summaries

### DIFF
--- a/.github/workflows/release-channel-rtt.yml
+++ b/.github/workflows/release-channel-rtt.yml
@@ -255,20 +255,25 @@ jobs:
 
           workspace_root="${GITHUB_WORKSPACE:?}"
           output_root=".artifacts/qa-e2e/${{ matrix.package.channel }}-release-rtt-${{ matrix.package.version }}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-          sample_paths="$RUNNER_TEMP/openclaw-${{ matrix.package.channel }}-${{ matrix.package.version }}-rtt-samples.tsv"
-          : >"$sample_paths"
           echo "output_root=${output_root}" >>"$GITHUB_OUTPUT"
 
           for sample in $(seq 1 "$samples"); do
             output_dir="${output_root}/sample-${sample}"
-            summary_path="${output_dir}/${{ matrix.package.summary }}"
+            summary_path="${output_dir}/rtt-summary.json"
             observed_path="${output_dir}/${{ matrix.package.observed }}"
             metrics_path="${output_dir}/resource-metrics.env"
             sample_started_at="$(date -u +"%Y-%m-%dT%H:%M:%S.%3NZ")"
             status=1
+            scenario_status="missing"
+            selector_status=2
+            selected_attempt_dir=""
+            rm -rf "$output_dir"
+            mkdir -p "$output_dir"
             for attempt in $(seq 1 "$max_attempts"); do
-              rm -rf "$output_dir"
-              mkdir -p "$output_dir"
+              attempt_dir="${output_dir}/attempt-${attempt}"
+              attempt_metrics_path="${attempt_dir}/resource-metrics.env"
+              rm -rf "$attempt_dir"
+              mkdir -p "$attempt_dir"
               echo "CHANNEL_RELEASE_RTT_PHASE:${{ matrix.package.channel }} version=${{ matrix.package.version }} sample=${sample}/${samples} attempt=${attempt}/${max_attempts}"
               # The release checkout can reactivate its shipped pnpm. Switch
               # back before invoking the current OpenClaw QA harness.
@@ -278,11 +283,11 @@ jobs:
                 cd "${workspace_root}/openclaw-qa"
                 /usr/bin/time \
                   -f 'max_rss_kb=%M\nelapsed_seconds=%e' \
-                  -o "${workspace_root}/openclaw/${metrics_path}" \
+                  -o "${workspace_root}/openclaw/${attempt_metrics_path}" \
                   timeout "${sample_timeout_seconds}s" \
                   pnpm openclaw qa "${{ matrix.package.channel }}" \
                   --repo-root "${workspace_root}/openclaw" \
-                  --output-dir "${output_dir}" \
+                  --output-dir "${attempt_dir}" \
                   --provider-mode mock-openai \
                   --model mock-openai/gpt-5.5 \
                   --alt-model mock-openai/gpt-5.5-alt \
@@ -298,12 +303,23 @@ jobs:
                 echo "sample=${sample}"
                 echo "attempts=${attempt}"
                 echo "exit_status=${status}"
-              } >>"$metrics_path"
-              scenario_status=""
-              if [[ -f "$summary_path" ]]; then
-                scenario_status="$(node -e 'const fs = require("node:fs"); const [summaryPath, scenarioId] = process.argv.slice(1); const summary = JSON.parse(fs.readFileSync(summaryPath, "utf8")); const scenario = Array.isArray(summary.scenarios) ? summary.scenarios.find((item) => item && item.id === scenarioId) : undefined; process.stdout.write(typeof scenario?.status === "string" ? scenario.status : "missing");' "$summary_path" "${{ matrix.package.scenario }}")"
+              } >>"$attempt_metrics_path"
+              set +e
+              scenario_status="$(
+                node "${workspace_root}/openclaw-rtt/scripts/select-channel-qa-summary.mjs" \
+                  "$attempt_dir" \
+                  "${{ matrix.package.summary }}" \
+                  "${{ matrix.package.channel }}" \
+                  "${{ matrix.package.scenario }}"
+              )"
+              selector_status="$?"
+              set -e
+              selected_attempt_dir="$attempt_dir"
+              if [[ "$selector_status" -eq 1 || "$selector_status" -gt 3 ]]; then
+                echo "${{ matrix.package.label }} QA summary selector failed with status ${selector_status}." >&2
+                exit 1
               fi
-              if [[ "$scenario_status" == "pass" ]]; then
+              if [[ "$selector_status" -eq 0 && "$scenario_status" == "pass" ]]; then
                 break
               fi
               if [[ "$attempt" -lt "$max_attempts" ]]; then
@@ -315,22 +331,26 @@ jobs:
                 sleep "$delay"
               fi
             done
-            if [[ ! -f "$summary_path" ]]; then
-              echo "No ${{ matrix.package.label }} QA summary produced for sample ${sample}; recording failed sample." >&2
+            cp "${selected_attempt_dir}/resource-metrics.env" "$metrics_path"
+            if [[ -f "${selected_attempt_dir}/${{ matrix.package.observed }}" ]]; then
+              cp "${selected_attempt_dir}/${{ matrix.package.observed }}" "$observed_path"
+            fi
+            if [[ -f "${selected_attempt_dir}/rtt-summary-source.json" ]]; then
+              cp "${selected_attempt_dir}/rtt-summary-source.json" "${output_dir}/rtt-summary-source.json"
+            fi
+            if [[ "$selector_status" -eq 0 ]]; then
+              cp "${selected_attempt_dir}/rtt-summary.json" "$summary_path"
+            else
+              echo "${{ matrix.package.label }} QA summary was ${scenario_status} for sample ${sample}; recording failed sample." >&2
               sample_finished_at="$(date -u +"%Y-%m-%dT%H:%M:%S.%3NZ")"
               node "${workspace_root}/openclaw-rtt/scripts/write-failed-channel-summary.mjs" \
                 "$summary_path" \
                 "${{ matrix.package.scenario }}" \
                 "${{ matrix.package.label }} canary" \
-                "QA command exited with status ${status} before writing a summary." \
+                "QA command exited with status ${status} after producing a ${scenario_status} summary." \
                 "$sample_started_at" \
                 "$sample_finished_at"
               scenario_status="fail"
-            fi
-            if [[ -f "$observed_path" ]]; then
-              printf '%s\t%s\t%s\n' "${PWD}/${summary_path}" "${PWD}/${observed_path}" "${PWD}/${metrics_path}" >>"$sample_paths"
-            else
-              printf '%s\t\t%s\n' "${PWD}/${summary_path}" "${PWD}/${metrics_path}" >>"$sample_paths"
             fi
             if [[ "$scenario_status" != "pass" ]]; then
               break
@@ -349,7 +369,7 @@ jobs:
           {
             echo "channel=${{ matrix.package.channel }}"
             echo "scenario=${{ matrix.package.scenario }}"
-            echo "summary=${{ matrix.package.summary }}"
+            echo "summary=rtt-summary.json"
             echo "observed=${{ matrix.package.observed }}"
             echo "spec=${{ matrix.package.spec }}"
             echo "version=${{ matrix.package.version }}"

--- a/scripts/release-workflow-contract.test.mjs
+++ b/scripts/release-workflow-contract.test.mjs
@@ -26,6 +26,30 @@ test("historical surface Chromium install uses the release dependency", async ()
   assert.doesNotMatch(step, /\b(?:scripts\/|ensure-playwright-chromium)\b/u);
 });
 
+test("historical channel workflow selects and imports a stable QA summary", async () => {
+  const workflow = await fs.readFile(new URL("release-channel-rtt.yml", workflowsDir), "utf8");
+  const measureStep = extractStep(workflow, "Run ${{ matrix.package.label }} RTT samples");
+  const prepareStep = extractStep(
+    workflow,
+    "Prepare ${{ matrix.package.label }} release import artifact",
+  );
+  const importStep = extractStep(workflow, "Import channel release RTT results");
+
+  assert.match(measureStep, /scripts\/select-channel-qa-summary\.mjs/u);
+  assert.match(measureStep, /"\$\{?selector_status\}?" -eq 0/u);
+  assert.match(measureStep, /"\$\{?scenario_status\}?" == "pass"/u);
+  assert.match(measureStep, /write-failed-channel-summary\.mjs" \\\n\s+"\$summary_path"/u);
+  assert.match(measureStep, /summary_path="\$\{output_dir\}\/rtt-summary\.json"/u);
+  assert.match(measureStep, /attempt_dir="\$\{output_dir\}\/attempt-\$\{attempt\}"/u);
+  assert.match(measureStep, /rtt-summary-source\.json/u);
+  assert.doesNotMatch(measureStep, /sample_paths/u);
+  assert.doesNotMatch(measureStep, /node -e/u);
+  assert.doesNotMatch(measureStep, /Array\.isArray\(summary\.scenarios\)/u);
+
+  assert.match(prepareStep, /echo "summary=rtt-summary\.json"/u);
+  assert.match(importStep, /summary_path="\$\{sample_dir\}\/\$\{summary\}"/u);
+});
+
 for (const filename of releaseWorkflows) {
   test(`${filename}: verifies the exact release tag commit`, async () => {
     const workflow = await fs.readFile(new URL(filename, workflowsDir), "utf8");

--- a/scripts/select-channel-qa-summary.mjs
+++ b/scripts/select-channel-qa-summary.mjs
@@ -1,0 +1,186 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+const STABLE_SUMMARY_FILENAME = "rtt-summary.json";
+const SOURCE_METADATA_FILENAME = "rtt-summary-source.json";
+
+class InvalidSummaryError extends Error {}
+
+function usage() {
+  return [
+    "Usage: node scripts/select-channel-qa-summary.mjs",
+    "  <output-dir> <canonical-filename> <channel> <scenario>",
+  ].join("\n");
+}
+
+function requireObject(value, label) {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new InvalidSummaryError(`${label} must be an object.`);
+  }
+  return value;
+}
+
+function requireString(value, label) {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new InvalidSummaryError(`${label} must be a non-empty string.`);
+  }
+  return value;
+}
+
+function requireNumber(value, label) {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new InvalidSummaryError(`${label} must be a finite number.`);
+  }
+  return value;
+}
+
+function validateEvidenceSummary(value, scenarioId) {
+  const summary = requireObject(value, "qa evidence");
+  if (summary.kind !== "openclaw.qa.evidence-summary") {
+    throw new InvalidSummaryError("qa evidence kind is not openclaw.qa.evidence-summary.");
+  }
+  requireString(summary.generatedAt, "qa evidence generatedAt");
+  if (!Array.isArray(summary.entries)) {
+    throw new InvalidSummaryError("qa evidence entries must be an array.");
+  }
+  const entry = summary.entries.find((item) => item?.test?.id === scenarioId);
+  if (!entry) {
+    throw new InvalidSummaryError(`qa evidence missing scenario ${scenarioId}.`);
+  }
+  const result = requireObject(entry.result, `qa evidence ${scenarioId} result`);
+  return requireString(result.status, `qa evidence ${scenarioId} result status`);
+}
+
+function validateLegacySummary(value, scenarioId) {
+  const summary = requireObject(value, "channel QA summary");
+  requireString(summary.startedAt, "channel QA summary startedAt");
+  requireString(summary.finishedAt, "channel QA summary finishedAt");
+  const counts = requireObject(summary.counts, "channel QA summary counts");
+  requireNumber(counts.total, "channel QA summary counts total");
+  requireNumber(counts.passed, "channel QA summary counts passed");
+  requireNumber(counts.failed, "channel QA summary counts failed");
+  if (!Array.isArray(summary.scenarios)) {
+    throw new InvalidSummaryError("channel QA summary scenarios must be an array.");
+  }
+  const scenario = summary.scenarios.find((item) => item?.id === scenarioId);
+  if (!scenario) {
+    throw new InvalidSummaryError(`channel QA summary missing scenario ${scenarioId}.`);
+  }
+  return requireString(scenario.status, `channel QA summary ${scenarioId} status`);
+}
+
+async function pathExists(pathname) {
+  try {
+    await fs.stat(pathname);
+    return true;
+  } catch (error) {
+    if (error?.code === "ENOENT") {
+      return false;
+    }
+    throw error;
+  }
+}
+
+async function writeSourceMetadata(outputDir, metadata) {
+  await fs.writeFile(
+    path.join(outputDir, SOURCE_METADATA_FILENAME),
+    `${JSON.stringify(metadata, null, 2)}\n`,
+  );
+}
+
+function metadata({ sourceFilename, schema, selection, scenario, status }) {
+  return { sourceFilename, schema, selection, scenario, status };
+}
+
+async function selectSummary(outputDir, canonicalFilename, channel, scenario) {
+  await fs.mkdir(outputDir, { recursive: true });
+  const stableSummaryPath = path.join(outputDir, STABLE_SUMMARY_FILENAME);
+  await fs.rm(stableSummaryPath, { force: true });
+
+  const canonicalPath = path.join(outputDir, canonicalFilename);
+  const legacyFilename = `${channel}-qa-summary.json`;
+  const legacyPath = path.join(outputDir, legacyFilename);
+  const hasCanonical = await pathExists(canonicalPath);
+  const hasLegacy = await pathExists(legacyPath);
+
+  if (!hasCanonical && !hasLegacy) {
+    await writeSourceMetadata(
+      outputDir,
+      metadata({
+        sourceFilename: null,
+        schema: null,
+        selection: "none",
+        scenario,
+        status: "missing",
+      }),
+    );
+    return { code: 2, status: "missing" };
+  }
+
+  const sourceFilename = hasCanonical ? canonicalFilename : legacyFilename;
+  const sourcePath = hasCanonical ? canonicalPath : legacyPath;
+  const schema = hasCanonical ? "openclaw.qa.evidence-summary" : "channel-qa-summary";
+  const selection = hasCanonical ? "canonical" : "legacy";
+
+  try {
+    const sourceBytes = await fs.readFile(sourcePath);
+    let parsed;
+    try {
+      parsed = JSON.parse(sourceBytes.toString("utf8"));
+    } catch (error) {
+      throw new InvalidSummaryError(`invalid JSON: ${error.message}`);
+    }
+    const producerStatus = hasCanonical
+      ? validateEvidenceSummary(parsed, scenario)
+      : validateLegacySummary(parsed, scenario);
+    const status = producerStatus === "pass" ? "pass" : "fail";
+    await fs.copyFile(sourcePath, stableSummaryPath);
+    await writeSourceMetadata(
+      outputDir,
+      metadata({ sourceFilename, schema, selection, scenario, status }),
+    );
+    return { code: 0, status };
+  } catch (error) {
+    if (!(error instanceof InvalidSummaryError)) {
+      throw error;
+    }
+    await writeSourceMetadata(
+      outputDir,
+      metadata({
+        sourceFilename,
+        schema,
+        selection,
+        scenario,
+        status: "invalid",
+      }),
+    );
+    console.error(`${sourceFilename}: ${error.message}`);
+    return { code: 3, status: "invalid" };
+  }
+}
+
+async function main() {
+  const [outputDir, canonicalFilename, channel, scenario, ...extra] = process.argv.slice(2);
+  if (
+    !outputDir ||
+    !canonicalFilename ||
+    path.basename(canonicalFilename) !== canonicalFilename ||
+    !channel ||
+    !scenario ||
+    extra.length > 0
+  ) {
+    console.error(usage());
+    return 1;
+  }
+
+  const result = await selectSummary(outputDir, canonicalFilename, channel, scenario);
+  process.stdout.write(`${result.status}\n`);
+  return result.code;
+}
+
+try {
+  process.exitCode = await main();
+} catch (error) {
+  console.error(error instanceof Error ? error.stack : String(error));
+  process.exitCode = 1;
+}

--- a/scripts/select-channel-qa-summary.test.mjs
+++ b/scripts/select-channel-qa-summary.test.mjs
@@ -1,0 +1,187 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const SELECT_SCRIPT = path.join(REPO_ROOT, "scripts/select-channel-qa-summary.mjs");
+
+async function makeOutputDir() {
+  return await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-rtt-summary-"));
+}
+
+async function writeJson(pathname, value) {
+  await fs.writeFile(pathname, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function modernSummary(scenario, status = "pass") {
+  return {
+    kind: "openclaw.qa.evidence-summary",
+    schemaVersion: 2,
+    generatedAt: "2026-09-03T00:00:00.000Z",
+    entries: [
+      {
+        test: { id: scenario, title: `${scenario} title` },
+        result: { status },
+      },
+    ],
+  };
+}
+
+function legacySummary(scenario, status = "pass") {
+  return {
+    startedAt: "2026-09-03T00:00:00.000Z",
+    finishedAt: "2026-09-03T00:00:01.000Z",
+    counts: {
+      total: 1,
+      passed: status === "pass" ? 1 : 0,
+      failed: status === "pass" ? 0 : 1,
+    },
+    scenarios: [{ id: scenario, status, rttMs: 4165 }],
+  };
+}
+
+function runSelector(outputDir, canonicalFilename, channel, scenario) {
+  return spawnSync(
+    process.execPath,
+    [SELECT_SCRIPT, outputDir, canonicalFilename, channel, scenario],
+    { encoding: "utf8" },
+  );
+}
+
+async function readMetadata(outputDir) {
+  return JSON.parse(await fs.readFile(path.join(outputDir, "rtt-summary-source.json"), "utf8"));
+}
+
+test("canonical evidence wins over a legacy summary and preserves exact bytes", async () => {
+  const outputDir = await makeOutputDir();
+  const canonicalBytes = `${JSON.stringify(modernSummary("slack-canary"), null, 3)}\n`;
+  await fs.writeFile(path.join(outputDir, "qa-evidence.json"), canonicalBytes);
+  await writeJson(
+    path.join(outputDir, "slack-qa-summary.json"),
+    legacySummary("slack-canary", "fail"),
+  );
+
+  const result = runSelector(outputDir, "qa-evidence.json", "slack", "slack-canary");
+
+  assert.equal(result.status, 0);
+  assert.equal(result.stdout, "pass\n");
+  assert.equal(
+    await fs.readFile(path.join(outputDir, "rtt-summary.json"), "utf8"),
+    canonicalBytes,
+  );
+  assert.deepEqual(await readMetadata(outputDir), {
+    sourceFilename: "qa-evidence.json",
+    schema: "openclaw.qa.evidence-summary",
+    selection: "canonical",
+    scenario: "slack-canary",
+    status: "pass",
+  });
+});
+
+test("legacy Slack summary is selected when canonical evidence is absent", async () => {
+  const outputDir = await makeOutputDir();
+  const legacyBytes = `${JSON.stringify(legacySummary("slack-canary"), null, 4)}\n`;
+  await fs.writeFile(path.join(outputDir, "slack-qa-summary.json"), legacyBytes);
+
+  const result = runSelector(outputDir, "qa-evidence.json", "slack", "slack-canary");
+
+  assert.equal(result.status, 0);
+  assert.equal(result.stdout, "pass\n");
+  assert.equal(await fs.readFile(path.join(outputDir, "rtt-summary.json"), "utf8"), legacyBytes);
+  assert.deepEqual(await readMetadata(outputDir), {
+    sourceFilename: "slack-qa-summary.json",
+    schema: "channel-qa-summary",
+    selection: "legacy",
+    scenario: "slack-canary",
+    status: "pass",
+  });
+});
+
+test("legacy WhatsApp non-pass status is normalized to fail", async () => {
+  const outputDir = await makeOutputDir();
+  await writeJson(
+    path.join(outputDir, "whatsapp-qa-summary.json"),
+    legacySummary("whatsapp-canary", "timeout"),
+  );
+
+  const result = runSelector(outputDir, "qa-evidence.json", "whatsapp", "whatsapp-canary");
+
+  assert.equal(result.status, 0);
+  assert.equal(result.stdout, "fail\n");
+  assert.equal((await readMetadata(outputDir)).status, "fail");
+});
+
+test("modern non-pass status is normalized to fail", async () => {
+  const outputDir = await makeOutputDir();
+  await writeJson(path.join(outputDir, "qa-evidence.json"), modernSummary("slack-canary", "skip"));
+
+  const result = runSelector(outputDir, "qa-evidence.json", "slack", "slack-canary");
+
+  assert.equal(result.status, 0);
+  assert.equal(result.stdout, "fail\n");
+  assert.equal((await readMetadata(outputDir)).status, "fail");
+});
+
+test("malformed canonical evidence blocks a valid legacy fallback", async () => {
+  const outputDir = await makeOutputDir();
+  await fs.writeFile(path.join(outputDir, "qa-evidence.json"), "{not-json}\n");
+  await writeJson(path.join(outputDir, "slack-qa-summary.json"), legacySummary("slack-canary"));
+
+  const result = runSelector(outputDir, "qa-evidence.json", "slack", "slack-canary");
+
+  assert.equal(result.status, 3);
+  assert.equal(result.stdout, "invalid\n");
+  await assert.rejects(fs.stat(path.join(outputDir, "rtt-summary.json")), { code: "ENOENT" });
+  assert.deepEqual(await readMetadata(outputDir), {
+    sourceFilename: "qa-evidence.json",
+    schema: "openclaw.qa.evidence-summary",
+    selection: "canonical",
+    scenario: "slack-canary",
+    status: "invalid",
+  });
+});
+
+test("canonical evidence missing the requested scenario blocks legacy fallback", async () => {
+  const outputDir = await makeOutputDir();
+  await writeJson(path.join(outputDir, "qa-evidence.json"), modernSummary("other-scenario"));
+  await writeJson(path.join(outputDir, "slack-qa-summary.json"), legacySummary("slack-canary"));
+
+  const result = runSelector(outputDir, "qa-evidence.json", "slack", "slack-canary");
+
+  assert.equal(result.status, 3);
+  assert.equal(result.stdout, "invalid\n");
+  assert.match(result.stderr, /missing scenario slack-canary/u);
+});
+
+test("missing canonical and legacy summaries reports missing", async () => {
+  const outputDir = await makeOutputDir();
+
+  const result = runSelector(outputDir, "qa-evidence.json", "slack", "slack-canary");
+
+  assert.equal(result.status, 2);
+  assert.equal(result.stdout, "missing\n");
+  assert.deepEqual(await readMetadata(outputDir), {
+    sourceFilename: null,
+    schema: null,
+    selection: "none",
+    scenario: "slack-canary",
+    status: "missing",
+  });
+});
+
+test("legacy summary must include importer-required fields and scenario", async () => {
+  const outputDir = await makeOutputDir();
+  const summary = legacySummary("slack-canary");
+  delete summary.counts;
+  await writeJson(path.join(outputDir, "slack-qa-summary.json"), summary);
+
+  const result = runSelector(outputDir, "qa-evidence.json", "slack", "slack-canary");
+
+  assert.equal(result.status, 3);
+  assert.equal(result.stdout, "invalid\n");
+  assert.match(result.stderr, /counts must be an object/u);
+});


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where historical Slack and WhatsApp release RTT jobs could complete their channel canary but import a synthetic failure because older OpenClaw tags write `<channel>-qa-summary.json` instead of `qa-evidence.json`.

The retry loop also only understood the legacy `scenarios[].status` shape, so current `qa-evidence.json` successes were not recognized as passing attempts.

## Why This Change Was Made

The workflow now selects one stable `rtt-summary.json` per attempt. Canonical `qa-evidence.json` wins when present; otherwise the selector accepts the historical channel summary. Malformed canonical evidence never falls through to a legacy file, and the importer remains responsible for RTT extraction and observed-message fallback.

## User Impact

RTT backfills can measure both historical and current OpenClaw releases without recording false zero-sample failures. Genuine producer failures, such as credential-pool exhaustion, remain visible with their original details.

## Evidence

- Live queue proof: https://github.com/openclaw/openclaw-rtt/actions/runs/33728672561 retained the full pending matrix after the concurrency fix.
- In that run, Slack `2026.5.16-beta.5` produced a passing legacy summary with `rttMs: 4165`, but the old workflow imported a synthetic `qa-evidence.json` failure because the canonical file was absent.
- A scheduled WhatsApp artifact produced a real credential-pool exhaustion failure; the old workflow replaced it with the same synthetic missing-summary failure.
- The new selector was run against both downloaded artifacts. It preserved the Slack summary byte-for-byte as `pass` and preserved the WhatsApp producer summary as `fail`.
- `node --test scripts/select-channel-qa-summary.test.mjs scripts/release-workflow-contract.test.mjs`: 13/13 pass
- `npm test`: 128/128 pass
- `npm run check`: pass
- `actionlint`: pass
- `git diff --check`: pass
- fresh Sol/high autoreview: no findings
- TruffleHog: clean
