### PR TITLE
fix(ci): recover modern channel RTT timing

### DIFF
--- a/.github/workflows/main-channel-rtt.yml
+++ b/.github/workflows/main-channel-rtt.yml
@@ -216,23 +216,30 @@ jobs:
 
           for sample in $(seq 1 "$samples"); do
             output_dir="${output_root}/sample-${sample}"
-            summary_path="${output_dir}/${{ matrix.summary }}"
+            summary_path="${output_dir}/rtt-summary.json"
             observed_path="${output_dir}/${{ matrix.observed }}"
             metrics_path="${output_dir}/resource-metrics.env"
             sample_started_at="$(date -u +"%Y-%m-%dT%H:%M:%S.%3NZ")"
             status=1
+            scenario_status="missing"
+            selector_status=2
+            selected_attempt_dir=""
+            rm -rf "$output_dir"
+            mkdir -p "$output_dir"
             for attempt in $(seq 1 "$max_attempts"); do
-              rm -rf "$output_dir"
-              mkdir -p "$output_dir"
+              attempt_dir="${output_dir}/attempt-${attempt}"
+              attempt_metrics_path="${attempt_dir}/resource-metrics.env"
+              rm -rf "$attempt_dir"
+              mkdir -p "$attempt_dir"
               echo "CHANNEL_RTT_PHASE:${{ matrix.channel }} sample=${sample}/${samples} attempt=${attempt}/${max_attempts}"
               set +e
               /usr/bin/time \
                 -f 'max_rss_kb=%M\nelapsed_seconds=%e' \
-                -o "$metrics_path" \
+                -o "$attempt_metrics_path" \
                 timeout "${sample_timeout_seconds}s" \
                 pnpm openclaw qa "${{ matrix.channel }}" \
                 --repo-root . \
-                --output-dir "${output_dir}" \
+                --output-dir "${attempt_dir}" \
                 --provider-mode mock-openai \
                 --model mock-openai/gpt-5.5 \
                 --alt-model mock-openai/gpt-5.5-alt \
@@ -247,12 +254,23 @@ jobs:
                 echo "sample=${sample}"
                 echo "attempts=${attempt}"
                 echo "exit_status=${status}"
-              } >>"$metrics_path"
-              scenario_status=""
-              if [[ -f "$summary_path" ]]; then
-                scenario_status="$(node -e 'const fs = require("node:fs"); const [summaryPath, scenarioId] = process.argv.slice(1); const summary = JSON.parse(fs.readFileSync(summaryPath, "utf8")); const scenario = Array.isArray(summary.scenarios) ? summary.scenarios.find((item) => item && item.id === scenarioId) : undefined; process.stdout.write(typeof scenario?.status === "string" ? scenario.status : "missing");' "$summary_path" "${{ matrix.scenario }}")"
+              } >>"$attempt_metrics_path"
+              set +e
+              scenario_status="$(
+                node "${GITHUB_WORKSPACE}/openclaw-rtt/scripts/select-channel-qa-summary.mjs" \
+                  "$attempt_dir" \
+                  "${{ matrix.summary }}" \
+                  "${{ matrix.channel }}" \
+                  "${{ matrix.scenario }}"
+              )"
+              selector_status="$?"
+              set -e
+              selected_attempt_dir="$attempt_dir"
+              if [[ "$selector_status" -eq 1 || "$selector_status" -gt 3 ]]; then
+                echo "${{ matrix.label }} QA summary selector failed with status ${selector_status}." >&2
+                exit 1
               fi
-              if [[ "$scenario_status" == "pass" ]]; then
+              if [[ "$selector_status" -eq 0 && "$scenario_status" == "pass" ]]; then
                 break
               fi
               if [[ "$attempt" -lt "$max_attempts" ]]; then
@@ -264,14 +282,26 @@ jobs:
                 sleep "$delay"
               fi
             done
-            if [[ ! -f "$summary_path" ]]; then
-              echo "No ${{ matrix.label }} QA summary produced for sample ${sample}; recording failed sample." >&2
+            cp "${selected_attempt_dir}/resource-metrics.env" "$metrics_path"
+            if [[ -f "${selected_attempt_dir}/${{ matrix.observed }}" ]]; then
+              cp "${selected_attempt_dir}/${{ matrix.observed }}" "$observed_path"
+            fi
+            if [[ -f "${selected_attempt_dir}/rtt-summary-source.json" ]]; then
+              cp "${selected_attempt_dir}/rtt-summary-source.json" "${output_dir}/rtt-summary-source.json"
+            fi
+            if [[ -f "${selected_attempt_dir}/qa-suite-summary.json" ]]; then
+              cp "${selected_attempt_dir}/qa-suite-summary.json" "${output_dir}/qa-suite-summary.json"
+            fi
+            if [[ "$selector_status" -eq 0 ]]; then
+              cp "${selected_attempt_dir}/rtt-summary.json" "$summary_path"
+            else
+              echo "${{ matrix.label }} QA summary was ${scenario_status} for sample ${sample}; recording failed sample." >&2
               sample_finished_at="$(date -u +"%Y-%m-%dT%H:%M:%S.%3NZ")"
               node "${GITHUB_WORKSPACE}/openclaw-rtt/scripts/write-failed-channel-summary.mjs" \
                 "$summary_path" \
                 "${{ matrix.scenario }}" \
                 "${{ matrix.label }} canary" \
-                "QA command exited with status ${status} before writing a summary." \
+                "QA command exited with status ${status} after producing a ${scenario_status} summary." \
                 "$sample_started_at" \
                 "$sample_finished_at"
               scenario_status="fail"
@@ -298,7 +328,7 @@ jobs:
           {
             echo "channel=${{ matrix.channel }}"
             echo "scenario=${{ matrix.scenario }}"
-            echo "summary=${{ matrix.summary }}"
+            echo "summary=rtt-summary.json"
             echo "observed=${{ matrix.observed }}"
             echo "version=${{ steps.openclaw_ref.outputs.version }}"
           } >"$import_dir/metadata.env"

--- a/.github/workflows/release-channel-rtt.yml
+++ b/.github/workflows/release-channel-rtt.yml
@@ -338,6 +338,9 @@ jobs:
             if [[ -f "${selected_attempt_dir}/rtt-summary-source.json" ]]; then
               cp "${selected_attempt_dir}/rtt-summary-source.json" "${output_dir}/rtt-summary-source.json"
             fi
+            if [[ -f "${selected_attempt_dir}/qa-suite-summary.json" ]]; then
+              cp "${selected_attempt_dir}/qa-suite-summary.json" "${output_dir}/qa-suite-summary.json"
+            fi
             if [[ "$selector_status" -eq 0 ]]; then
               cp "${selected_attempt_dir}/rtt-summary.json" "$summary_path"
             else

--- a/scripts/import-live-transport-rtt.mjs
+++ b/scripts/import-live-transport-rtt.mjs
@@ -100,7 +100,7 @@ function validateSummary(value) {
 
 function normalizeEvidenceSummary(value, scenarioId) {
   if (value?.kind !== "openclaw.qa.evidence-summary") {
-    return value;
+    return { summary: value };
   }
   const entries = Array.isArray(value.entries) ? value.entries : [];
   const entry = entries.find((item) => item?.test?.id === scenarioId);
@@ -114,26 +114,30 @@ function normalizeEvidenceSummary(value, scenarioId) {
     timing && typeof timing === "object" && !Array.isArray(timing) ? timing.rttMs : undefined;
   const passed = entries.filter((item) => item?.result?.status === "pass").length;
   return {
-    startedAt: generatedAt,
-    finishedAt: generatedAt,
-    counts: {
-      total: entries.length,
-      passed,
-      failed: entries.length - passed,
-    },
-    scenarios: [
-      {
-        id: scenarioId,
-        status: result.status === "pass" ? "pass" : "fail",
-        ...(typeof rttMs === "number" && Number.isFinite(rttMs)
-          ? { rttMs: Math.max(0, Math.round(rttMs)) }
-          : {}),
-        ...(typeof result.details === "string" ? { details: result.details } : {}),
+    evidenceEntry: entry,
+    summary: {
+      startedAt: generatedAt,
+      finishedAt: generatedAt,
+      counts: {
+        total: entries.length,
+        passed,
+        failed: entries.length - passed,
       },
-    ],
-    credentials: {
-      source: entry.execution?.provider?.fixture ?? entry.execution?.provider?.auth,
-      role: "ci",
+      scenarios: [
+        {
+          id: scenarioId,
+          title: entry.test?.title,
+          status: result.status === "pass" ? "pass" : "fail",
+          ...(typeof rttMs === "number" && Number.isFinite(rttMs)
+            ? { rttMs: Math.max(0, Math.round(rttMs)) }
+            : {}),
+          ...(typeof result.details === "string" ? { details: result.details } : {}),
+        },
+      ],
+      credentials: {
+        source: entry.execution?.provider?.fixture ?? entry.execution?.provider?.auth,
+        role: "ci",
+      },
     },
   };
 }
@@ -238,6 +242,86 @@ function extractScenarioMeasurement(scenario) {
   };
 }
 
+// Some released evidence declared a suite summary but omitted structured RTT.
+// Follow only that exact sibling artifact so arbitrary files or prose cannot become measurements.
+function selectQaSuiteArtifact(entry) {
+  const artifacts = Array.isArray(entry?.execution?.artifacts)
+    ? entry.execution.artifacts.filter(
+        (artifact) => artifact?.kind === "summary" && artifact?.source === "qa-suite",
+      )
+    : [];
+  if (artifacts.length === 0) {
+    return undefined;
+  }
+  if (artifacts.length !== 1) {
+    throw new Error("qa evidence must declare exactly one qa-suite summary artifact.");
+  }
+  const artifactPath = artifacts[0]?.path;
+  if (typeof artifactPath !== "string" || artifactPath.length === 0) {
+    throw new Error("qa-suite summary artifact path must be a non-empty string.");
+  }
+  if (artifactPath.includes("\0")) {
+    throw new Error("qa-suite summary artifact path must not contain NUL.");
+  }
+  if (path.posix.isAbsolute(artifactPath) || path.win32.isAbsolute(artifactPath)) {
+    throw new Error("qa-suite summary artifact path must be relative.");
+  }
+  if (artifactPath.includes("/") || artifactPath.includes("\\")) {
+    throw new Error("qa-suite summary artifact path must be a filename.");
+  }
+  if (artifactPath === "." || artifactPath === "..") {
+    throw new Error("qa-suite summary artifact path must not traverse directories.");
+  }
+  if (artifactPath !== "qa-suite-summary.json") {
+    throw new Error("qa-suite summary artifact path must be qa-suite-summary.json.");
+  }
+  return artifactPath;
+}
+
+async function extractQaSuiteRtt(evidenceEntry, summaryPath) {
+  if (evidenceEntry?.result?.status !== "pass") {
+    return undefined;
+  }
+  const artifactFilename = selectQaSuiteArtifact(evidenceEntry);
+  if (!artifactFilename) {
+    return undefined;
+  }
+  let suite;
+  try {
+    suite = await readJson(path.join(path.dirname(summaryPath), artifactFilename));
+  } catch (error) {
+    if (error?.code === "ENOENT") {
+      // Some immutable runs declared the suite artifact but did not upload it.
+      // That leaves timing unprovable, so retain the sample as failed.
+      return undefined;
+    }
+    throw error;
+  }
+  const title = evidenceEntry.test?.title;
+  if (typeof title !== "string" || !Array.isArray(suite?.scenarios)) {
+    return undefined;
+  }
+  // Historical suite scenarios expose no stable id. Their exact unique title
+  // is the only cross-artifact key; ambiguity must not produce a measurement.
+  const scenarios = suite.scenarios.filter((scenario) => scenario?.name === title);
+  if (scenarios.length !== 1 || scenarios[0]?.status !== "pass") {
+    return undefined;
+  }
+  const steps = Array.isArray(scenarios[0].steps) ? scenarios[0].steps : [];
+  const matches = steps.flatMap((step) => {
+    if (step?.name !== title || step?.status !== "pass" || typeof step.details !== "string") {
+      return [];
+    }
+    const match = /^reply matched in ([1-9][0-9]*)ms(?:;|$)/u.exec(step.details);
+    if (!match) {
+      return [];
+    }
+    const rttMs = Number(match[1]);
+    return Number.isSafeInteger(rttMs) ? [rttMs] : [];
+  });
+  return matches.length === 1 ? matches[0] : undefined;
+}
+
 async function readResourceMetrics(pathname) {
   if (!pathname) {
     return {};
@@ -296,9 +380,9 @@ function selectScenario(summary, scenarioId) {
 }
 
 async function readSample(entry, index, scenarioId) {
-  const summary = validateSummary(
-    normalizeEvidenceSummary(await readJson(path.resolve(entry.summaryPath)), scenarioId),
-  );
+  const summaryPath = path.resolve(entry.summaryPath);
+  const normalized = normalizeEvidenceSummary(await readJson(summaryPath), scenarioId);
+  const summary = validateSummary(normalized.summary);
   const scenario = selectScenario(summary, scenarioId);
   const rttMeasurement = extractScenarioMeasurement(scenario);
   const summaryRttMs =
@@ -311,6 +395,10 @@ async function readSample(entry, index, scenarioId) {
   if (rttMs === undefined && entry.observedMessagesPath) {
     rttMs = extractObservedRtt(await readJson(path.resolve(entry.observedMessagesPath)), scenarioId);
     rttSource = rttMs === undefined ? undefined : "observed-message";
+  }
+  if (rttMs === undefined && normalized.evidenceEntry) {
+    rttMs = await extractQaSuiteRtt(normalized.evidenceEntry, summaryPath);
+    rttSource = rttMs === undefined ? undefined : "qa-suite-details";
   }
   const resourceMetrics = await readResourceMetrics(entry.resourceMetricsPath);
   const attempts = readAttemptCount(resourceMetrics.attempts);

--- a/scripts/import-live-transport-rtt.test.mjs
+++ b/scripts/import-live-transport-rtt.test.mjs
@@ -28,6 +28,100 @@ async function readJsonl(pathname) {
     .map((line) => JSON.parse(line));
 }
 
+function modernEvidence({
+  artifacts = [
+    { kind: "summary", path: "qa-suite-summary.json", source: "qa-suite" },
+    { kind: "report", path: "qa-suite-report.md", source: "qa-suite" },
+  ],
+  status = "pass",
+  timing,
+  title = "Slack canary echo",
+} = {}) {
+  return {
+    kind: "openclaw.qa.evidence-summary",
+    schemaVersion: 2,
+    generatedAt: "2026-09-03T08:44:53.550Z",
+    entries: [
+      {
+        test: { id: "slack-canary", title },
+        execution: {
+          provider: { fixture: "mock-openai" },
+          artifacts,
+        },
+        result: {
+          status,
+          ...(timing ? { timing } : {}),
+        },
+      },
+    ],
+  };
+}
+
+function qaSuiteSummary({
+  scenarioName = "Slack canary echo",
+  scenarioStatus = "pass",
+  steps = [
+    {
+      name: "Slack canary echo",
+      status: "pass",
+      details: "reply matched in 2857ms",
+    },
+  ],
+} = {}) {
+  return {
+    scenarios: [{ name: scenarioName, status: scenarioStatus, steps }],
+    counts: {
+      total: 1,
+      passed: scenarioStatus === "pass" ? 1 : 0,
+      failed: scenarioStatus === "pass" ? 0 : 1,
+    },
+  };
+}
+
+async function importModernSlack({
+  companion = qaSuiteSummary(),
+  companionBytes,
+  evidence = modernEvidence(),
+  includeCompanion = true,
+  observed,
+} = {}) {
+  const workspace = await makeWorkspace();
+  const sampleDir = path.join(workspace, "sample-1");
+  const summaryPath = path.join(sampleDir, "rtt-summary.json");
+  const observedPath = path.join(sampleDir, "slack-qa-observed-messages.json");
+  await writeJson(summaryPath, evidence);
+  if (companionBytes !== undefined) {
+    await fs.writeFile(path.join(sampleDir, "qa-suite-summary.json"), companionBytes);
+  } else if (includeCompanion) {
+    await writeJson(path.join(sampleDir, "qa-suite-summary.json"), companion);
+  }
+  if (observed !== undefined) {
+    await writeJson(observedPath, observed);
+  }
+  const samplesPath = path.join(workspace, "samples.tsv");
+  await fs.writeFile(samplesPath, `${summaryPath}\t${observed ? observedPath : ""}\n`);
+  await execFileAsync(
+    process.execPath,
+    [
+      IMPORT_SCRIPT,
+      samplesPath,
+      "--channel",
+      "slack",
+      "--spec",
+      "openclaw@main",
+      "--version",
+      "2026.7.2-beta.2",
+      "--provider-mode",
+      "mock-openai",
+    ],
+    { cwd: workspace },
+  );
+  const [row] = await readJsonl(
+    path.join(workspace, "data/channels/slack/2026.7.2-beta.2.jsonl"),
+  );
+  return { row, workspace };
+}
+
 test("imports live transport summary RTT samples", async () => {
   const workspace = await makeWorkspace();
   const summaryPath = path.join(workspace, "sample-1", "slack-qa-summary.json");
@@ -153,6 +247,172 @@ test("imports channel qa-evidence summaries", async () => {
   assert.equal(row.run.status, "pass");
   assert.deepEqual(row.rtt.warmSamples, [456]);
   assert.deepEqual(row.rtt.sources, ["summary-rtt"]);
+});
+
+test("imports RTT from the exact modern Slack qa-suite companion shape", async () => {
+  const { row } = await importModernSlack();
+
+  assert.equal(row.run.status, "pass");
+  assert.deepEqual(row.rtt.warmSamples, [2857]);
+  assert.deepEqual(row.rtt.sources, ["qa-suite-details"]);
+  assert.equal(row.samples[0].rttSource, "qa-suite-details");
+});
+
+test("keeps structured and observed RTT ahead of qa-suite details", async () => {
+  const observed = [
+    {
+      scenarioId: "slack-canary",
+      matchedScenario: true,
+      triggerTimestamp: "2026-09-03T08:44:50.000Z",
+      timestamp: "2026-09-03T08:44:50.777Z",
+    },
+  ];
+  const structured = await importModernSlack({
+    evidence: modernEvidence({ timing: { rttMs: 456 } }),
+    observed,
+  });
+  assert.deepEqual(structured.row.rtt.warmSamples, [456]);
+  assert.deepEqual(structured.row.rtt.sources, ["summary-rtt"]);
+
+  const observedFallback = await importModernSlack({ observed });
+  assert.deepEqual(observedFallback.row.rtt.warmSamples, [777]);
+  assert.deepEqual(observedFallback.row.rtt.sources, ["observed-message"]);
+});
+
+for (const {
+  name,
+  companion,
+  evidence,
+  includeCompanion,
+} of [
+  {
+    name: "wrong suite scenario title",
+    companion: qaSuiteSummary({ scenarioName: "Another scenario" }),
+  },
+  {
+    name: "failed evidence",
+    evidence: modernEvidence({ status: "fail" }),
+  },
+  {
+    name: "failed suite scenario",
+    companion: qaSuiteSummary({ scenarioStatus: "fail" }),
+  },
+  {
+    name: "failed matching step",
+    companion: qaSuiteSummary({
+      steps: [
+        {
+          name: "Slack canary echo",
+          status: "fail",
+          details: "reply matched in 2857ms",
+        },
+      ],
+    }),
+  },
+  {
+    name: "unanchored suite details",
+    companion: qaSuiteSummary({
+      steps: [
+        {
+          name: "Slack canary echo",
+          status: "pass",
+          details: "completed; reply matched in 2857ms",
+        },
+      ],
+    }),
+  },
+  {
+    name: "ambiguous suite details",
+    companion: qaSuiteSummary({
+      steps: [
+        {
+          name: "Slack canary echo",
+          status: "pass",
+          details: "reply matched in 2857ms",
+        },
+        {
+          name: "Slack canary echo",
+          status: "pass",
+          details: "reply matched in 2900ms; duplicate",
+        },
+      ],
+    }),
+  },
+  {
+    name: "missing suite companion",
+    includeCompanion: false,
+  },
+]) {
+  test(`imports a failed sample for ${name}`, async () => {
+    const { row } = await importModernSlack({
+      companion,
+      evidence,
+      includeCompanion,
+    });
+    assert.equal(row.run.status, "fail");
+    assert.deepEqual(row.rtt.warmSamples, []);
+    assert.equal(row.samples[0].rttMs, undefined);
+  });
+}
+
+for (const { name, path: artifactPath, error } of [
+  {
+    name: "absolute artifact paths",
+    path: "/tmp/qa-suite-summary.json",
+    error: /artifact path must be relative/u,
+  },
+  {
+    name: "Windows absolute artifact paths",
+    path: "C:\\temp\\qa-suite-summary.json",
+    error: /artifact path must be relative/u,
+  },
+  {
+    name: "traversal artifact paths",
+    path: "../qa-suite-summary.json",
+    error: /artifact path must be a filename/u,
+  },
+  {
+    name: "relative artifact paths with separators",
+    path: "nested/qa-suite-summary.json",
+    error: /artifact path must be a filename/u,
+  },
+  {
+    name: "NUL artifact paths",
+    path: "qa-suite-summary.json\0",
+    error: /artifact path must not contain NUL/u,
+  },
+]) {
+  test(`rejects ${name}`, async () => {
+    await assert.rejects(
+      importModernSlack({
+        evidence: modernEvidence({
+          artifacts: [{ kind: "summary", path: artifactPath, source: "qa-suite" }],
+        }),
+      }),
+      error,
+    );
+  });
+}
+
+test("rejects duplicate qa-suite summary artifacts", async () => {
+  await assert.rejects(
+    importModernSlack({
+      evidence: modernEvidence({
+        artifacts: [
+          { kind: "summary", path: "qa-suite-summary.json", source: "qa-suite" },
+          { kind: "summary", path: "qa-suite-summary.json", source: "qa-suite" },
+        ],
+      }),
+    }),
+    /exactly one qa-suite summary artifact/u,
+  );
+});
+
+test("rejects malformed qa-suite companion JSON", async () => {
+  await assert.rejects(
+    importModernSlack({ companionBytes: "{not-json}\n" }),
+    /Unexpected token|Expected property name/u,
+  );
 });
 
 test("falls back to observed message timestamps when summaries do not carry RTT", async () => {

--- a/scripts/release-workflow-contract.test.mjs
+++ b/scripts/release-workflow-contract.test.mjs
@@ -42,7 +42,34 @@ test("historical channel workflow selects and imports a stable QA summary", asyn
   assert.match(measureStep, /summary_path="\$\{output_dir\}\/rtt-summary\.json"/u);
   assert.match(measureStep, /attempt_dir="\$\{output_dir\}\/attempt-\$\{attempt\}"/u);
   assert.match(measureStep, /rtt-summary-source\.json/u);
+  assert.match(
+    measureStep,
+    /if \[\[ -f "\$\{selected_attempt_dir\}\/qa-suite-summary\.json" \]\]; then\n\s+cp "\$\{selected_attempt_dir\}\/qa-suite-summary\.json" "\$\{output_dir\}\/qa-suite-summary\.json"/u,
+  );
   assert.doesNotMatch(measureStep, /sample_paths/u);
+  assert.doesNotMatch(measureStep, /node -e/u);
+  assert.doesNotMatch(measureStep, /Array\.isArray\(summary\.scenarios\)/u);
+
+  assert.match(prepareStep, /echo "summary=rtt-summary\.json"/u);
+  assert.match(importStep, /summary_path="\$\{sample_dir\}\/\$\{summary\}"/u);
+});
+
+test("main channel workflow selects stable evidence and preserves its suite companion", async () => {
+  const workflow = await fs.readFile(new URL("main-channel-rtt.yml", workflowsDir), "utf8");
+  const measureStep = extractStep(workflow, "Run ${{ matrix.label }} RTT samples");
+  const prepareStep = extractStep(workflow, "Prepare ${{ matrix.label }} import artifact");
+  const importStep = extractStep(workflow, "Import channel RTT results");
+
+  assert.match(measureStep, /scripts\/select-channel-qa-summary\.mjs/u);
+  assert.match(measureStep, /"\$\{?selector_status\}?" -eq 0/u);
+  assert.match(measureStep, /"\$\{?scenario_status\}?" == "pass"/u);
+  assert.match(measureStep, /summary_path="\$\{output_dir\}\/rtt-summary\.json"/u);
+  assert.match(measureStep, /attempt_dir="\$\{output_dir\}\/attempt-\$\{attempt\}"/u);
+  assert.match(measureStep, /rtt-summary-source\.json/u);
+  assert.match(
+    measureStep,
+    /if \[\[ -f "\$\{selected_attempt_dir\}\/qa-suite-summary\.json" \]\]; then\n\s+cp "\$\{selected_attempt_dir\}\/qa-suite-summary\.json" "\$\{output_dir\}\/qa-suite-summary\.json"/u,
+  );
   assert.doesNotMatch(measureStep, /node -e/u);
   assert.doesNotMatch(measureStep, /Array\.isArray\(summary\.scenarios\)/u);
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where passing Slack QA runs from immutable OpenClaw releases were recorded as RTT failures when canonical evidence omitted structured timing, and where main-channel retries misread canonical evidence as missing.

Related: https://github.com/openclaw/openclaw-rtt/pull/56
Related: https://github.com/openclaw/openclaw/pull/137013

## Why This Change Was Made

The importer now follows only the selected canonical evidence entry's declared `qa-suite-summary.json` artifact when structured and observed timing are absent. Release and main workflows preserve that companion beside the stable selected summary, and main-channel retry decisions now use the existing summary selector instead of a legacy-only inline parser.

The fallback is intentionally narrow: exact artifact metadata and filename, exact unique scenario title, passing evidence/scenario/step, and an anchored `reply matched in Nms` detail. Structured measurements and observed timestamps retain precedence.

## User Impact

Historical Slack releases can produce truthful RTT rows instead of false failures, while current main-channel jobs stop wasting retries on valid canonical evidence.

## Evidence

- Archived `2026.7.2-beta.2` artifact imports as pass at `2857ms` with source `qa-suite-details`.
- Focused importer/workflow tests: 26/26 passed.
- Full suite: 145/145 passed.
- `npm run check`: passed.
- `actionlint` on both changed workflows: passed.
- `git diff --check`: passed.
- Fresh autoreview: clean, no accepted/actionable findings.
- Exact head: `8ab2147e776899f5411cbcc60b59e1f6576ed9e9`.
