### PR TITLE
fix(ci): keep RTT reports on one code revision

### DIFF
--- a/.github/workflows/main-channel-rtt.yml
+++ b/.github/workflows/main-channel-rtt.yml
@@ -368,6 +368,14 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Archive workflow scripts
+        shell: bash
+        run: |
+          set -euo pipefail
+          scripts_archive_dir="$(mktemp -d "$RUNNER_TEMP/rtt-workflow-scripts.XXXXXX")"
+          git archive "${{ github.workflow_sha }}" scripts | tar -x -C "$scripts_archive_dir"
+          printf 'RTT_SCRIPTS_DIR=%s\n' "$scripts_archive_dir/scripts" >>"$GITHUB_ENV"
+
       - name: Setup Node
         uses: actions/setup-node@v7
         with:
@@ -430,16 +438,16 @@ jobs:
                 printf '%s\t\t%s\n' "$summary_path" "$metrics_path" >>"$sample_paths"
               fi
             done < <(find "${import_dir}/artifacts" -mindepth 1 -maxdepth 1 -type d -name 'sample-*' | sort -V)
-            node scripts/import-live-transport-rtt.mjs "$sample_paths" \
+            node "$RTT_SCRIPTS_DIR/import-live-transport-rtt.mjs" "$sample_paths" \
               --channel "$channel" \
               --spec openclaw@main \
               --version "$version" \
               --provider-mode mock-openai \
               --scenario "$scenario"
           done
-          node scripts/update-readme.mjs --latest-main-only
-          node scripts/validate.mjs
-          node scripts/channel-rtt-summary.mjs
+          node "$RTT_SCRIPTS_DIR/update-readme.mjs" --latest-main-only
+          node "$RTT_SCRIPTS_DIR/validate.mjs"
+          node "$RTT_SCRIPTS_DIR/channel-rtt-summary.mjs"
 
       - name: Commit result
         if: github.event_name != 'pull_request'
@@ -463,8 +471,8 @@ jobs:
               echo "Channel RTT import is already present after rebase."
               exit 0
             fi
-            node scripts/update-readme.mjs --latest-main-only
-            node scripts/validate.mjs
+            node "$RTT_SCRIPTS_DIR/update-readme.mjs" --latest-main-only
+            node "$RTT_SCRIPTS_DIR/validate.mjs"
             git add README.md
             git commit --amend --no-edit
             git push

--- a/.github/workflows/main-discord-rtt.yml
+++ b/.github/workflows/main-discord-rtt.yml
@@ -37,6 +37,15 @@ jobs:
           path: openclaw-rtt
           fetch-depth: 0
 
+      - name: Archive workflow scripts
+        working-directory: openclaw-rtt
+        shell: bash
+        run: |
+          set -euo pipefail
+          scripts_archive_dir="$(mktemp -d "$RUNNER_TEMP/rtt-workflow-scripts.XXXXXX")"
+          git archive "${{ github.workflow_sha }}" scripts | tar -x -C "$scripts_archive_dir"
+          printf 'RTT_SCRIPTS_DIR=%s\n' "$scripts_archive_dir/scripts" >>"$GITHUB_ENV"
+
       - name: Checkout OpenClaw main
         uses: actions/checkout@v7
         with:
@@ -185,13 +194,13 @@ jobs:
         run: |
           set -euo pipefail
           git pull --rebase origin main
-          node scripts/import-discord-rtt.mjs "${{ steps.discord_rtt.outputs.sample_paths }}" \
+          node "$RTT_SCRIPTS_DIR/import-discord-rtt.mjs" "${{ steps.discord_rtt.outputs.sample_paths }}" \
             --spec openclaw@main \
             --version "${{ steps.openclaw_ref.outputs.version }}" \
             --provider-mode mock-openai
-          node scripts/update-readme.mjs --latest-main-only
-          node scripts/validate.mjs
-          node scripts/discord-rtt-summary.mjs
+          node "$RTT_SCRIPTS_DIR/update-readme.mjs" --latest-main-only
+          node "$RTT_SCRIPTS_DIR/validate.mjs"
+          node "$RTT_SCRIPTS_DIR/discord-rtt-summary.mjs"
 
       - name: Upload Discord RTT artifacts
         if: always()
@@ -224,8 +233,8 @@ jobs:
               echo "Discord RTT import is already present after rebase."
               exit 0
             fi
-            node scripts/update-readme.mjs --latest-main-only
-            node scripts/validate.mjs
+            node "$RTT_SCRIPTS_DIR/update-readme.mjs" --latest-main-only
+            node "$RTT_SCRIPTS_DIR/validate.mjs"
             git add README.md
             git commit --amend --no-edit
             git push

--- a/.github/workflows/main-rtt.yml
+++ b/.github/workflows/main-rtt.yml
@@ -36,6 +36,15 @@ jobs:
           path: openclaw-rtt
           fetch-depth: 0
 
+      - name: Archive workflow scripts
+        working-directory: openclaw-rtt
+        shell: bash
+        run: |
+          set -euo pipefail
+          scripts_archive_dir="$(mktemp -d "$RUNNER_TEMP/rtt-workflow-scripts.XXXXXX")"
+          git archive "${{ github.workflow_sha }}" scripts | tar -x -C "$scripts_archive_dir"
+          printf 'RTT_SCRIPTS_DIR=%s\n' "$scripts_archive_dir/scripts" >>"$GITHUB_ENV"
+
       - name: Checkout OpenClaw main
         uses: actions/checkout@v7
         with:
@@ -207,16 +216,16 @@ jobs:
         run: |
           set -euo pipefail
           git pull --rebase origin main
-          node scripts/import-result.mjs "${{ steps.rtt.outputs.evidence_path }}" \
+          node "$RTT_SCRIPTS_DIR/import-result.mjs" "${{ steps.rtt.outputs.evidence_path }}" \
             --spec openclaw@main \
             --version "${{ steps.pack.outputs.package_version }}" \
             --scenario telegram-reply-chain-exact-marker \
             --started-at "${{ steps.rtt.outputs.started_at }}" \
             --finished-at "${{ steps.rtt.outputs.finished_at }}" \
             --resource-metrics "${{ steps.rtt.outputs.resource_metrics_path }}"
-          node scripts/update-readme.mjs --latest-main-only
-          node scripts/validate.mjs
-          node scripts/summary.mjs
+          node "$RTT_SCRIPTS_DIR/update-readme.mjs" --latest-main-only
+          node "$RTT_SCRIPTS_DIR/validate.mjs"
+          node "$RTT_SCRIPTS_DIR/summary.mjs"
 
       - name: Commit result
         if: steps.rtt.outputs.status == '0'
@@ -241,8 +250,8 @@ jobs:
               echo "Telegram RTT import is already present after rebase."
               exit 0
             fi
-            node scripts/update-readme.mjs --latest-main-only
-            node scripts/validate.mjs
+            node "$RTT_SCRIPTS_DIR/update-readme.mjs" --latest-main-only
+            node "$RTT_SCRIPTS_DIR/validate.mjs"
             git add README.md
             git commit --amend --no-edit
             git push

--- a/.github/workflows/main-surface-rtt.yml
+++ b/.github/workflows/main-surface-rtt.yml
@@ -53,6 +53,15 @@ jobs:
           path: openclaw-rtt
           fetch-depth: 0
 
+      - name: Archive workflow scripts
+        working-directory: openclaw-rtt
+        shell: bash
+        run: |
+          set -euo pipefail
+          scripts_archive_dir="$(mktemp -d "$RUNNER_TEMP/rtt-workflow-scripts.XXXXXX")"
+          git archive "${{ github.workflow_sha }}" scripts | tar -x -C "$scripts_archive_dir"
+          printf 'RTT_SCRIPTS_DIR=%s\n' "$scripts_archive_dir/scripts" >>"$GITHUB_ENV"
+
       - name: Checkout OpenClaw main
         uses: actions/checkout@v7
         with:
@@ -156,7 +165,7 @@ jobs:
             /usr/bin/time \
               -f 'max_rss_kb=%M\nelapsed_seconds=%e' \
               -o "$metrics_path" \
-              node --import tsx ../openclaw-rtt/scripts/measure-rpc-rtt.mjs \
+              node --import tsx "$RTT_SCRIPTS_DIR/measure-rpc-rtt.mjs" \
               --output-dir "$output_dir"
             echo "attempts=1" >>"$metrics_path"
             printf '%s\t%s\n' \
@@ -180,7 +189,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          node scripts/import-surface-rtt.mjs \
+          node "$RTT_SCRIPTS_DIR/import-surface-rtt.mjs" \
             "${{ steps.rpc_surface_rtt.outputs.sample_paths }}" \
             --surface rpc \
             --spec openclaw@main \
@@ -226,7 +235,7 @@ jobs:
             /usr/bin/time \
               -f 'max_rss_kb=%M\nelapsed_seconds=%e' \
               -o "$metrics_path" \
-              node --import tsx ../openclaw-rtt/scripts/measure-control-ui-rtt.mjs \
+              node --import tsx "$RTT_SCRIPTS_DIR/measure-control-ui-rtt.mjs" \
               --output-dir "$output_dir"
             echo "attempts=1" >>"$metrics_path"
             printf '%s\t%s\t%s\n' \
@@ -251,7 +260,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          node scripts/import-surface-rtt.mjs \
+          node "$RTT_SCRIPTS_DIR/import-surface-rtt.mjs" \
             "${{ steps.surface_rtt.outputs.sample_paths }}" \
             --surface control-ui \
             --spec openclaw@main \
@@ -265,9 +274,9 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          node scripts/update-readme.mjs --latest-main-only
-          node scripts/validate.mjs
-          node scripts/surface-rtt-summary.mjs
+          node "$RTT_SCRIPTS_DIR/update-readme.mjs" --latest-main-only
+          node "$RTT_SCRIPTS_DIR/validate.mjs"
+          node "$RTT_SCRIPTS_DIR/surface-rtt-summary.mjs"
 
       - name: Commit imported Surface RTT
         if: always() && github.event_name != 'pull_request' && (steps.import_rpc_surface_rtt.outcome == 'success' || steps.import_control_ui_surface_rtt.outcome == 'success')
@@ -292,8 +301,8 @@ jobs:
               echo "Surface RTT import is already present after rebase."
               exit 0
             fi
-            node scripts/update-readme.mjs --latest-main-only
-            node scripts/validate.mjs
+            node "$RTT_SCRIPTS_DIR/update-readme.mjs" --latest-main-only
+            node "$RTT_SCRIPTS_DIR/validate.mjs"
             git add README.md
             git commit --amend --no-edit
             git push

--- a/.github/workflows/readme-hydration.yml
+++ b/.github/workflows/readme-hydration.yml
@@ -54,6 +54,14 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Archive workflow scripts
+        shell: bash
+        run: |
+          set -euo pipefail
+          scripts_archive_dir="$(mktemp -d "$RUNNER_TEMP/rtt-workflow-scripts.XXXXXX")"
+          git archive "${{ github.workflow_sha }}" scripts | tar -x -C "$scripts_archive_dir"
+          printf 'RTT_SCRIPTS_DIR=%s\n' "$scripts_archive_dir/scripts" >>"$GITHUB_ENV"
+
       - name: Setup Node
         uses: actions/setup-node@v7
         with:
@@ -64,12 +72,12 @@ jobs:
         run: |
           set -euo pipefail
           git pull --rebase origin main
-          node scripts/update-readme.mjs
-          node scripts/validate.mjs
-          node scripts/summary.mjs
-          node scripts/discord-rtt-summary.mjs
-          node scripts/channel-rtt-summary.mjs
-          node scripts/surface-rtt-summary.mjs
+          node "$RTT_SCRIPTS_DIR/update-readme.mjs"
+          node "$RTT_SCRIPTS_DIR/validate.mjs"
+          node "$RTT_SCRIPTS_DIR/summary.mjs"
+          node "$RTT_SCRIPTS_DIR/discord-rtt-summary.mjs"
+          node "$RTT_SCRIPTS_DIR/channel-rtt-summary.mjs"
+          node "$RTT_SCRIPTS_DIR/surface-rtt-summary.mjs"
 
       - name: Commit README
         shell: bash
@@ -85,7 +93,7 @@ jobs:
           git commit -m "docs: hydrate rtt readme"
           git push || {
             git pull --rebase origin main
-            node scripts/update-readme.mjs
+            node "$RTT_SCRIPTS_DIR/update-readme.mjs"
             if git diff --quiet --exit-code README.md; then
               git push
               exit 0

--- a/.github/workflows/release-channel-rtt.yml
+++ b/.github/workflows/release-channel-rtt.yml
@@ -433,6 +433,14 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Archive workflow scripts
+        shell: bash
+        run: |
+          set -euo pipefail
+          scripts_archive_dir="$(mktemp -d "$RUNNER_TEMP/rtt-workflow-scripts.XXXXXX")"
+          git archive "${{ github.workflow_sha }}" scripts | tar -x -C "$scripts_archive_dir"
+          printf 'RTT_SCRIPTS_DIR=%s\n' "$scripts_archive_dir/scripts" >>"$GITHUB_ENV"
+
       - name: Setup Node
         uses: actions/setup-node@v7
         with:
@@ -458,7 +466,7 @@ jobs:
             import_dirs=("$import_root")
           fi
           if [[ "${#import_dirs[@]}" -eq 0 ]]; then
-            node scripts/handle-missing-release-imports.mjs channel "$MEASURE_RESULT"
+            node "$RTT_SCRIPTS_DIR/handle-missing-release-imports.mjs" channel "$MEASURE_RESULT"
             exit 0
           fi
           get_metadata() {
@@ -490,16 +498,16 @@ jobs:
                 printf '%s\t\t%s\n' "$summary_path" "$metrics_path" >>"$sample_paths"
               fi
             done < <(find "${import_dir}/artifacts" -mindepth 1 -maxdepth 1 -type d -name 'sample-*' | sort -V)
-            node scripts/import-live-transport-rtt.mjs "$sample_paths" \
+            node "$RTT_SCRIPTS_DIR/import-live-transport-rtt.mjs" "$sample_paths" \
               --channel "$channel" \
               --spec "$spec" \
               --version "$version" \
               --provider-mode mock-openai \
               --scenario "$scenario"
           done
-          node scripts/update-readme.mjs
-          node scripts/validate.mjs
-          node scripts/channel-rtt-summary.mjs
+          node "$RTT_SCRIPTS_DIR/update-readme.mjs"
+          node "$RTT_SCRIPTS_DIR/validate.mjs"
+          node "$RTT_SCRIPTS_DIR/channel-rtt-summary.mjs"
 
       - name: Commit result
         shell: bash
@@ -522,8 +530,8 @@ jobs:
               echo "Channel release RTT import is already present after rebase."
               exit 0
             fi
-            node scripts/update-readme.mjs
-            node scripts/validate.mjs
+            node "$RTT_SCRIPTS_DIR/update-readme.mjs"
+            node "$RTT_SCRIPTS_DIR/validate.mjs"
             git add README.md
             git commit --amend --no-edit
             git push

--- a/.github/workflows/release-surface-rtt.yml
+++ b/.github/workflows/release-surface-rtt.yml
@@ -272,6 +272,14 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Archive workflow scripts
+        shell: bash
+        run: |
+          set -euo pipefail
+          scripts_archive_dir="$(mktemp -d "$RUNNER_TEMP/rtt-workflow-scripts.XXXXXX")"
+          git archive "${{ github.workflow_sha }}" scripts | tar -x -C "$scripts_archive_dir"
+          printf 'RTT_SCRIPTS_DIR=%s\n' "$scripts_archive_dir/scripts" >>"$GITHUB_ENV"
+
       - name: Setup Node
         uses: actions/setup-node@v7
         with:
@@ -297,7 +305,7 @@ jobs:
             import_dirs=("$import_root")
           fi
           if [[ "${#import_dirs[@]}" -eq 0 ]]; then
-            node scripts/handle-missing-release-imports.mjs surface "$MEASURE_RESULT"
+            node "$RTT_SCRIPTS_DIR/handle-missing-release-imports.mjs" surface "$MEASURE_RESULT"
             exit 0
           fi
           get_metadata() {
@@ -333,7 +341,7 @@ jobs:
               fi
             done < <(find "${import_dir}/artifacts" -mindepth 1 -maxdepth 1 -type d -name 'sample-*' | sort -V)
             import_args=(
-              node scripts/import-surface-rtt.mjs "$sample_paths"
+              node "$RTT_SCRIPTS_DIR/import-surface-rtt.mjs" "$sample_paths"
               --surface "$surface"
               --spec "$spec"
               --version "$version"
@@ -345,9 +353,9 @@ jobs:
             fi
             "${import_args[@]}"
           done
-          node scripts/update-readme.mjs
-          node scripts/validate.mjs
-          node scripts/surface-rtt-summary.mjs
+          node "$RTT_SCRIPTS_DIR/update-readme.mjs"
+          node "$RTT_SCRIPTS_DIR/validate.mjs"
+          node "$RTT_SCRIPTS_DIR/surface-rtt-summary.mjs"
 
       - name: Commit result
         shell: bash
@@ -370,8 +378,8 @@ jobs:
               echo "Surface release RTT import is already present after rebase."
               exit 0
             fi
-            node scripts/update-readme.mjs
-            node scripts/validate.mjs
+            node "$RTT_SCRIPTS_DIR/update-readme.mjs"
+            node "$RTT_SCRIPTS_DIR/validate.mjs"
             git add README.md
             git commit --amend --no-edit
             git push

--- a/.github/workflows/stable-release-discord-rtt.yml
+++ b/.github/workflows/stable-release-discord-rtt.yml
@@ -346,6 +346,14 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Archive workflow scripts
+        shell: bash
+        run: |
+          set -euo pipefail
+          scripts_archive_dir="$(mktemp -d "$RUNNER_TEMP/rtt-workflow-scripts.XXXXXX")"
+          git archive "${{ github.workflow_sha }}" scripts | tar -x -C "$scripts_archive_dir"
+          printf 'RTT_SCRIPTS_DIR=%s\n' "$scripts_archive_dir/scripts" >>"$GITHUB_ENV"
+
       - name: Setup Node
         uses: actions/setup-node@v7
         with:
@@ -371,7 +379,7 @@ jobs:
             import_dirs=("$import_root")
           fi
           if [[ "${#import_dirs[@]}" -eq 0 ]]; then
-            node scripts/handle-missing-release-imports.mjs Discord "$MEASURE_RESULT"
+            node "$RTT_SCRIPTS_DIR/handle-missing-release-imports.mjs" Discord "$MEASURE_RESULT"
             exit 0
           fi
           get_metadata() {
@@ -400,21 +408,21 @@ jobs:
               printf '%s\t%s\t%s\n' "$summary_path" "$observed_value" "$metrics_path" >>"$sample_paths"
             done < <(find "${import_dir}/artifacts" -mindepth 1 -maxdepth 1 -type d -name 'sample-*' | sort -V)
             if [[ "${{ needs.resolve.outputs.rss_backfill }}" == "true" ]]; then
-              node scripts/backfill-release-rss.mjs \
+              node "$RTT_SCRIPTS_DIR/backfill-release-rss.mjs" \
                 --family discord \
                 --spec "$spec" \
                 --version "$version" \
                 --sample-paths "$sample_paths"
             else
-              node scripts/import-discord-rtt.mjs "$sample_paths" \
+              node "$RTT_SCRIPTS_DIR/import-discord-rtt.mjs" "$sample_paths" \
                 --spec "$spec" \
                 --version "$version" \
                 --provider-mode mock-openai
             fi
           done
-          node scripts/update-readme.mjs
-          node scripts/validate.mjs
-          node scripts/discord-rtt-summary.mjs
+          node "$RTT_SCRIPTS_DIR/update-readme.mjs"
+          node "$RTT_SCRIPTS_DIR/validate.mjs"
+          node "$RTT_SCRIPTS_DIR/discord-rtt-summary.mjs"
 
       - name: Commit result
         shell: bash
@@ -437,8 +445,8 @@ jobs:
               echo "Discord release RTT import is already present after rebase."
               exit 0
             fi
-            node scripts/update-readme.mjs
-            node scripts/validate.mjs
+            node "$RTT_SCRIPTS_DIR/update-readme.mjs"
+            node "$RTT_SCRIPTS_DIR/validate.mjs"
             git add README.md
             git commit --amend --no-edit
             git push

--- a/.github/workflows/stable-release-rtt.yml
+++ b/.github/workflows/stable-release-rtt.yml
@@ -54,6 +54,15 @@ jobs:
           path: openclaw-rtt
           fetch-depth: 0
 
+      - name: Archive workflow scripts
+        working-directory: openclaw-rtt
+        shell: bash
+        run: |
+          set -euo pipefail
+          scripts_archive_dir="$(mktemp -d "$RUNNER_TEMP/rtt-workflow-scripts.XXXXXX")"
+          git archive "${{ github.workflow_sha }}" scripts | tar -x -C "$scripts_archive_dir"
+          printf 'RTT_SCRIPTS_DIR=%s\n' "$scripts_archive_dir/scripts" >>"$GITHUB_ENV"
+
       - name: Setup Node
         uses: actions/setup-node@v7
         with:
@@ -179,13 +188,13 @@ jobs:
             (
               cd ../openclaw-rtt
               git pull --rebase origin "${GITHUB_REF_NAME:-main}"
-              node scripts/backfill-release-rss.mjs \
+              node "$RTT_SCRIPTS_DIR/backfill-release-rss.mjs" \
                 --family telegram \
                 --spec "$spec" \
                 --version "$version" \
                 --resource-metrics "$metrics_path"
-              node scripts/update-readme.mjs
-              node scripts/validate.mjs
+              node "$RTT_SCRIPTS_DIR/update-readme.mjs"
+              node "$RTT_SCRIPTS_DIR/validate.mjs"
               git add data/channels/telegram/ runs/telegram/ README.md
               if git diff --cached --quiet --exit-code; then
                 echo "No RSS changes to commit for $spec."
@@ -203,8 +212,8 @@ jobs:
                   echo "Telegram RSS import is already present after rebase."
                   exit 0
                 fi
-                node scripts/update-readme.mjs
-                node scripts/validate.mjs
+                node "$RTT_SCRIPTS_DIR/update-readme.mjs"
+                node "$RTT_SCRIPTS_DIR/validate.mjs"
                 git add README.md
                 git commit --amend --no-edit
                 git push
@@ -288,16 +297,16 @@ jobs:
           set -euo pipefail
           git pull --rebase origin "${GITHUB_REF_NAME:-main}"
           while IFS=$'\t' read -r evidence_path metrics_path version started_at finished_at; do
-            node scripts/import-result.mjs "$evidence_path" \
+            node "$RTT_SCRIPTS_DIR/import-result.mjs" "$evidence_path" \
               --version "$version" \
               --scenario telegram-reply-chain-exact-marker \
               --started-at "$started_at" \
               --finished-at "$finished_at" \
               --resource-metrics "$metrics_path"
           done <"${{ steps.rtt.outputs.result_paths }}"
-          node scripts/update-readme.mjs
-          node scripts/validate.mjs
-          node scripts/summary.mjs
+          node "$RTT_SCRIPTS_DIR/update-readme.mjs"
+          node "$RTT_SCRIPTS_DIR/validate.mjs"
+          node "$RTT_SCRIPTS_DIR/summary.mjs"
 
       - name: Commit result
         if: steps.release.outputs.should_run == 'true' && steps.release.outputs.rss_backfill != 'true'
@@ -322,8 +331,8 @@ jobs:
               echo "Telegram release RTT import is already present after rebase."
               exit 0
             fi
-            node scripts/update-readme.mjs
-            node scripts/validate.mjs
+            node "$RTT_SCRIPTS_DIR/update-readme.mjs"
+            node "$RTT_SCRIPTS_DIR/validate.mjs"
             git add README.md
             git commit --amend --no-edit
             git push

--- a/scripts/data-import-readme-workflow.test.mjs
+++ b/scripts/data-import-readme-workflow.test.mjs
@@ -136,8 +136,8 @@ function assertOrdered(contents, commands, context) {
 
 function readmeCommand(mode) {
   return mode === "main"
-    ? "node scripts/update-readme.mjs --latest-main-only"
-    : "node scripts/update-readme.mjs";
+    ? 'node "$RTT_SCRIPTS_DIR/update-readme.mjs" --latest-main-only'
+    : 'node "$RTT_SCRIPTS_DIR/update-readme.mjs"';
 }
 
 test("all nine data import paths update README atomically", async (t) => {
@@ -158,7 +158,7 @@ test("all nine data import paths update README atomically", async (t) => {
 
       assertOrdered(
         importStep,
-        [generation, "node scripts/validate.mjs"],
+        [generation, 'node "$RTT_SCRIPTS_DIR/validate.mjs"'],
         `${pathConfig.name} initial import`,
       );
       assert.match(
@@ -169,7 +169,9 @@ test("all nine data import paths update README atomically", async (t) => {
 
       const generationLine = importStep
         .split("\n")
-        .find((line) => line.trim().startsWith("node scripts/update-readme.mjs"));
+        .find((line) =>
+          line.trim().startsWith('node "$RTT_SCRIPTS_DIR/update-readme.mjs"'),
+        );
       assert.equal(generationLine?.trim(), generation, `${pathConfig.name} uses the wrong README mode`);
 
       if (!pathConfig.retry) {
@@ -187,7 +189,7 @@ test("all nine data import paths update README atomically", async (t) => {
           pathConfig.upstreamGuard,
           "exit 0",
           generation,
-          "node scripts/validate.mjs",
+          'node "$RTT_SCRIPTS_DIR/validate.mjs"',
           "git add README.md",
           "git commit --amend --no-edit",
           "git push",

--- a/scripts/pinned-workflow-scripts.test.mjs
+++ b/scripts/pinned-workflow-scripts.test.mjs
@@ -1,0 +1,287 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import fs from "node:fs/promises";
+import { builtinModules } from "node:module";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import test from "node:test";
+
+const execFileAsync = promisify(execFile);
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const SCRIPTS_ROOT = path.join(REPO_ROOT, "scripts");
+const WORKFLOW_FILES = [
+  ".github/workflows/main-rtt.yml",
+  ".github/workflows/main-discord-rtt.yml",
+  ".github/workflows/main-channel-rtt.yml",
+  ".github/workflows/main-surface-rtt.yml",
+  ".github/workflows/stable-release-rtt.yml",
+  ".github/workflows/stable-release-discord-rtt.yml",
+  ".github/workflows/release-channel-rtt.yml",
+  ".github/workflows/release-surface-rtt.yml",
+  ".github/workflows/readme-hydration.yml",
+];
+const WRITER_PATHS = [
+  {
+    name: "main Telegram",
+    workflow: ".github/workflows/main-rtt.yml",
+    writerStep: "Import result",
+    checkoutPath: "openclaw-rtt",
+  },
+  {
+    name: "main Discord",
+    workflow: ".github/workflows/main-discord-rtt.yml",
+    writerStep: "Import Discord RTT result",
+    checkoutPath: "openclaw-rtt",
+  },
+  {
+    name: "main channel",
+    workflow: ".github/workflows/main-channel-rtt.yml",
+    writerStep: "Import channel RTT results",
+  },
+  {
+    name: "main surface",
+    workflow: ".github/workflows/main-surface-rtt.yml",
+    writerStep: "Refresh RTT tracker",
+    checkoutPath: "openclaw-rtt",
+  },
+  {
+    name: "release Telegram RSS backfill",
+    workflow: ".github/workflows/stable-release-rtt.yml",
+    writerStep: "Run RSS backfill",
+    checkoutPath: "openclaw-rtt",
+  },
+  {
+    name: "release Telegram",
+    workflow: ".github/workflows/stable-release-rtt.yml",
+    writerStep: "Import result",
+    checkoutPath: "openclaw-rtt",
+  },
+  {
+    name: "release Discord",
+    workflow: ".github/workflows/stable-release-discord-rtt.yml",
+    writerStep: "Import Discord release RTT results",
+  },
+  {
+    name: "release channel",
+    workflow: ".github/workflows/release-channel-rtt.yml",
+    writerStep: "Import channel release RTT results",
+  },
+  {
+    name: "release surface",
+    workflow: ".github/workflows/release-surface-rtt.yml",
+    writerStep: "Import surface release RTT results",
+  },
+  {
+    name: "README hydration",
+    workflow: ".github/workflows/readme-hydration.yml",
+    writerStep: "Hydrate README",
+  },
+];
+const EXPECTED_ENTRYPOINTS = [
+  "backfill-release-rss.mjs",
+  "channel-rtt-summary.mjs",
+  "discord-rtt-summary.mjs",
+  "handle-missing-release-imports.mjs",
+  "import-discord-rtt.mjs",
+  "import-live-transport-rtt.mjs",
+  "import-result.mjs",
+  "import-surface-rtt.mjs",
+  "measure-control-ui-rtt.mjs",
+  "measure-rpc-rtt.mjs",
+  "summary.mjs",
+  "surface-rtt-summary.mjs",
+  "update-readme.mjs",
+  "validate.mjs",
+];
+const ALLOWED_DYNAMIC_IMPORTS = new Map([
+  ["measure-control-ui-rtt.mjs", ["helperUrl"]],
+  ["measure-rpc-rtt.mjs", ["clientUrl"]],
+]);
+
+function workflowSteps(contents) {
+  const matches = [...contents.matchAll(/^      - name: (.+)$/gmu)];
+  return matches.map((match, index) => ({
+    contents: contents.slice(match.index, matches[index + 1]?.index ?? contents.length),
+    index: match.index,
+    name: match[1],
+  }));
+}
+
+function moduleSpecifiers(source) {
+  const specifiers = new Set();
+  const patterns = [
+    /^\s*import\s+(?:[^"'()]*?\s+from\s+)?["']([^"']+)["']/gmu,
+    /^\s*export\s+[^"']*?\s+from\s+["']([^"']+)["']/gmu,
+    /\bimport\s*\(\s*["']([^"']+)["']\s*\)/gu,
+  ];
+  for (const pattern of patterns) {
+    for (const match of source.matchAll(pattern)) {
+      specifiers.add(match[1]);
+    }
+  }
+  return [...specifiers];
+}
+
+function dynamicImportExpressions(source) {
+  return [...source.matchAll(/\bimport\s*\(\s*([^)\r\n]+?)\s*\)/gu)]
+    .map((match) => match[1])
+    .filter((expression) => !/^["'][^"']+["']$/u.test(expression));
+}
+
+test("all nine workflows snapshot scripts before ten writer pulls", async (t) => {
+  assert.equal(WORKFLOW_FILES.length, 9);
+  assert.equal(WRITER_PATHS.length, 10);
+  const workflowCache = new Map();
+  const pinnedEntrypoints = new Set();
+
+  for (const writer of WRITER_PATHS) {
+    await t.test(writer.name, async () => {
+      let contents = workflowCache.get(writer.workflow);
+      if (!contents) {
+        contents = await fs.readFile(path.join(REPO_ROOT, writer.workflow), "utf8");
+        workflowCache.set(writer.workflow, contents);
+      }
+      const steps = workflowSteps(contents);
+      const writerIndex = steps.findIndex((step) => step.name === writer.writerStep);
+      assert.notEqual(writerIndex, -1, `${writer.workflow}: missing ${writer.writerStep}`);
+      const checkoutIndex = steps.findLastIndex(
+        (step, index) => index < writerIndex && step.name === "Checkout RTT tracker",
+      );
+      assert.notEqual(checkoutIndex, -1, `${writer.workflow}: missing writer checkout`);
+
+      const checkout = steps[checkoutIndex];
+      const archive = steps[checkoutIndex + 1];
+      const writerStep = steps[writerIndex];
+      assert.equal(
+        archive?.name,
+        "Archive workflow scripts",
+        `${writer.name}: archive must immediately follow the writer checkout`,
+      );
+      if (writer.checkoutPath) {
+        assert.match(checkout.contents, new RegExp(`path: ${writer.checkoutPath}\\n`, "u"));
+        assert.match(
+          archive.contents,
+          new RegExp(`working-directory: ${writer.checkoutPath}\\n`, "u"),
+        );
+      } else {
+        assert.doesNotMatch(archive.contents, /working-directory:/u);
+      }
+      assert.match(
+        archive.contents,
+        /scripts_archive_dir="\$\(mktemp -d "\$RUNNER_TEMP\/rtt-workflow-scripts\.XXXXXX"\)"/u,
+      );
+      assert.match(
+        archive.contents,
+        /git archive "\$\{\{ github\.workflow_sha \}\}" scripts \| tar -x -C "\$scripts_archive_dir"/u,
+      );
+      assert.match(
+        archive.contents,
+        /printf 'RTT_SCRIPTS_DIR=%s\\n' "\$scripts_archive_dir\/scripts" >>"\$GITHUB_ENV"/u,
+      );
+      assert.doesNotMatch(archive.contents, /^\s*cd /mu);
+
+      const pullIndex = writerStep.contents.indexOf("git pull --rebase");
+      assert.notEqual(pullIndex, -1, `${writer.name}: writer must update its checkout`);
+      assert.ok(archive.index < writerStep.index, `${writer.name}: archive must precede the pull`);
+      const absolutePullIndex = writerStep.index + pullIndex;
+      const afterPull = contents.slice(absolutePullIndex);
+      assert.doesNotMatch(
+        afterPull,
+        /\bnode\s+(?:--import\s+tsx\s+)?(?:scripts\/|(?:\.\.\/|\$\{[^}]+\}\/)openclaw-rtt\/scripts\/)[^\s\\]+\.mjs/u,
+        `${writer.name}: post-pull RTT entrypoint must use RTT_SCRIPTS_DIR`,
+      );
+      for (const match of afterPull.matchAll(/"\$RTT_SCRIPTS_DIR\/([^"]+\.mjs)"/gu)) {
+        pinnedEntrypoints.add(match[1]);
+      }
+    });
+  }
+
+  assert.deepEqual([...pinnedEntrypoints].sort(), EXPECTED_ENTRYPOINTS);
+});
+
+test("archived workflow entrypoints keep their module dependency closure available", async () => {
+  const nodeBuiltins = new Set(builtinModules.flatMap((name) => [name, `node:${name}`]));
+  const pending = EXPECTED_ENTRYPOINTS.map((entrypoint) => path.join(SCRIPTS_ROOT, entrypoint));
+  const visited = new Set();
+
+  while (pending.length > 0) {
+    const current = pending.pop();
+    if (visited.has(current)) {
+      continue;
+    }
+    visited.add(current);
+    const source = await fs.readFile(current, "utf8");
+    const relativePath = path.relative(REPO_ROOT, current);
+    for (const specifier of moduleSpecifiers(source)) {
+      if (nodeBuiltins.has(specifier)) {
+        continue;
+      }
+      assert.ok(
+        specifier.startsWith("."),
+        `${relativePath} imports non-archived module ${specifier}`,
+      );
+      const importedPath = path.resolve(path.dirname(current), specifier);
+      assert.ok(
+        importedPath.startsWith(`${SCRIPTS_ROOT}${path.sep}`),
+        `${relativePath} imports outside scripts/: ${specifier}`,
+      );
+      await fs.access(importedPath);
+      pending.push(importedPath);
+    }
+    assert.deepEqual(
+      dynamicImportExpressions(source),
+      ALLOWED_DYNAMIC_IMPORTS.get(path.basename(current)) ?? [],
+      `${relativePath} has an unaccounted dynamic import`,
+    );
+  }
+});
+
+test("commit A workflow scripts survive deletion in commit B", async (t) => {
+  const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "rtt-pinned-scripts-"));
+  t.after(() => fs.rm(tempRoot, { force: true, recursive: true }));
+  const repo = path.join(tempRoot, "repo");
+  const scripts = path.join(repo, "scripts");
+  const archive = path.join(tempRoot, "archive");
+  const archiveTar = path.join(tempRoot, "scripts.tar");
+  await fs.mkdir(scripts, { recursive: true });
+  await fs.mkdir(archive);
+  await fs.writeFile(
+    path.join(scripts, "helper.mjs"),
+    'export const revision = "commit-a";\n',
+  );
+  await fs.writeFile(
+    path.join(scripts, "entrypoint.mjs"),
+    'import { revision } from "./helper.mjs";\nprocess.stdout.write(`${revision}\\n`);\n',
+  );
+  await execFileAsync("git", ["init", "--quiet"], { cwd: repo });
+  await execFileAsync("git", ["config", "user.name", "RTT Test"], { cwd: repo });
+  await execFileAsync("git", ["config", "user.email", "rtt-test@example.invalid"], {
+    cwd: repo,
+  });
+  await execFileAsync("git", ["add", "scripts"], { cwd: repo });
+  await execFileAsync("git", ["commit", "--quiet", "-m", "commit A"], { cwd: repo });
+  const { stdout: commitAOutput } = await execFileAsync("git", ["rev-parse", "HEAD"], {
+    cwd: repo,
+  });
+  const commitA = commitAOutput.trim();
+
+  await execFileAsync(
+    "git",
+    ["archive", "--format=tar", `--output=${archiveTar}`, commitA, "scripts"],
+    { cwd: repo },
+  );
+  await execFileAsync("tar", ["-xf", archiveTar, "-C", archive]);
+  await fs.rm(scripts, { recursive: true });
+  await execFileAsync("git", ["add", "--all"], { cwd: repo });
+  await execFileAsync("git", ["commit", "--quiet", "-m", "commit B deletes scripts"], {
+    cwd: repo,
+  });
+
+  await assert.rejects(fs.access(path.join(repo, "scripts", "entrypoint.mjs")));
+  const { stdout } = await execFileAsync(process.execPath, [
+    path.join(archive, "scripts", "entrypoint.mjs"),
+  ]);
+  assert.equal(stdout, "commit-a\n");
+});

--- a/scripts/release-report-workflow.test.mjs
+++ b/scripts/release-report-workflow.test.mjs
@@ -53,7 +53,7 @@ test("release report workflows preserve partial imports without cascade failures
     assert.match(
       contents,
       new RegExp(
-        `node scripts/handle-missing-release-imports\\.mjs ${workflow.family} "\\$MEASURE_RESULT"`,
+        `node "\\$RTT_SCRIPTS_DIR/handle-missing-release-imports\\.mjs" ${workflow.family} "\\$MEASURE_RESULT"`,
         "u",
       ),
     );


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where RTT report jobs could fail after successful measurements when `main` changed during the run. The writer would pull newer repository code, then continue executing the older workflow shell against scripts that had changed or been deleted.

Observed failure: https://github.com/openclaw/openclaw-rtt/actions/runs/33742748099

## Why This Change Was Made

Each writer now archives the tracked `scripts/` tree from `${{ github.workflow_sha }}` before pulling current data from `main`. Importers, measurement helpers, README generators, summaries, validators, and retry paths execute from that immutable snapshot while the checkout still rebases current RTT data for concurrent-writer safety.

This applies the same revision invariant across all nine report-writing workflows instead of repairing only the release-channel path that exposed the race.

## User Impact

RTT runs can finish reporting with the exact tooling revision that started the workflow, even when later commits delete or reshape reporting scripts. Successful measurements no longer get stranded by a mixed-revision import failure.

## Evidence

- 27 focused Node tests passed.
- Regression coverage proves a commit-A script snapshot still executes after commit B deletes the script.
- Contract coverage checks all nine workflows, ten writer paths, post-pull pinned entrypoints, retry ordering, and archived module dependency closure.
- `node --check` passed for all changed test scripts.
- `actionlint` passed for all nine changed workflows.
- `git diff --check` passed.
- Fresh P0-P2 autoreview: scoped clean, confidence 0.89.
