### PR TITLE
fix: pin complete Slack QA owner repair

### DIFF
--- a/scripts/openclaw-qa-harness.mjs
+++ b/scripts/openclaw-qa-harness.mjs
@@ -1,1 +1,1 @@
-export const OPENCLAW_QA_HARNESS_SHA = "b03e0ec8cf8effb19a4e8043a5a3c1dacd418812";
+export const OPENCLAW_QA_HARNESS_SHA = "84eb1ec03bf237ae2ad0ffacd3804d52c21162bc";


### PR DESCRIPTION
## What Problem This Solves

Slack release RTT jobs still checked out the earlier partial QA harness repair, so they could miss the complete plugin-owned Slack dependency-resolution fix.

## Why This Change Was Made

Pins the shared immutable OpenClaw QA harness revision to `84eb1ec03bf237ae2ad0ffacd3804d52c21162bc`, the complete owner-boundary repair from https://github.com/openclaw/openclaw/pull/137346. Channel and Discord release resolvers continue to consume the single shared pin.

## User Impact

Slack release RTT runs use the complete private-QA plugin facade repair without expanding RTT production logic or changing stored measurements.

## Evidence

- Focused harness consumers: 19/19 tests passed.
- Full `npm test`: 161/161 tests passed.
- `npm run check`: 4,062 stored rows validated and README parity remained clean.
- Exact Slack startup proof: https://github.com/openclaw/openclaw-rtt/actions/runs/33771350656 checked out `84eb1ec03bf237ae2ad0ffacd3804d52c21162bc`, built private QA, and passed `slack-canary` on attempt 1 with no Slack package-resolution failure. The importer committed durable row `2026.8.1+84eb1ec03b` with RTT 3,028 ms.
- Diff: 1 insertion, 1 deletion; net 0 LOC.
