### PR TITLE
fix: preserve structured QA RTT provenance

### DIFF
--- a/scripts/import-discord-rtt.mjs
+++ b/scripts/import-discord-rtt.mjs
@@ -101,8 +101,9 @@ function normalizeEvidenceSummary(value) {
     throw new Error("qa evidence missing discord-canary.");
   }
   const generatedAt = requireString(value.generatedAt, "qa evidence generatedAt");
-  const status = entry.result?.status === "pass" ? "pass" : "fail";
-  const timing = entry.result?.timing;
+  const result = entry.result;
+  const status = result?.status === "pass" ? "pass" : "fail";
+  const timing = result?.timing;
   const rttMs =
     timing && typeof timing === "object" && !Array.isArray(timing) ? timing.rttMs : undefined;
   if (rttMs !== undefined && (typeof rttMs !== "number" || !Number.isFinite(rttMs))) {
@@ -122,7 +123,10 @@ function normalizeEvidenceSummary(value) {
         id: "discord-canary",
         status,
         ...(rttMs === undefined ? {} : { rttMs }),
-        details: entry.result?.details ?? entry.result?.failure?.reason,
+        ...(result?.rttMeasurement === undefined
+          ? {}
+          : { rttMeasurement: result.rttMeasurement }),
+        details: result?.details ?? result?.failure?.reason,
       },
     ],
     credentials: {

--- a/scripts/import-discord-rtt.test.mjs
+++ b/scripts/import-discord-rtt.test.mjs
@@ -103,9 +103,15 @@ test("imports Discord qa-evidence summaries", async () => {
   assert.equal(row.mode.providerMode, "mock-openai");
 });
 
-test("imports Discord qa-evidence without the retired observed-message sidecar", async () => {
+test("preserves Discord qa-evidence RTT measurement without the retired sidecar", async () => {
   const workspace = await makeWorkspace();
   const sampleDir = path.join(workspace, "sample-1");
+  const rttMeasurement = {
+    finalMatchedReplyRttMs: 1875,
+    requestStartedAt: "2026-07-18T03:59:07.000Z",
+    responseObservedAt: "2026-07-18T03:59:08.875Z",
+    source: "request-to-observed-message",
+  };
   await fs.mkdir(sampleDir, { recursive: true });
   await fs.writeFile(
     path.join(sampleDir, "qa-evidence.json"),
@@ -117,7 +123,11 @@ test("imports Discord qa-evidence without the retired observed-message sidecar",
         {
           test: { id: "discord-canary", title: "Discord canary echo" },
           execution: { provider: { fixture: "mock-openai" } },
-          result: { status: "pass", timing: { rttMs: 2140 } },
+          result: {
+            status: "pass",
+            timing: { rttMs: 2140 },
+            rttMeasurement,
+          },
         },
       ],
     })}\n`,
@@ -145,8 +155,9 @@ test("imports Discord qa-evidence without the retired observed-message sidecar",
     .split("\n")
     .map((line) => JSON.parse(line));
   assert.equal(row.run.status, "pass");
-  assert.equal(row.rtt.p50Ms, 2140);
-  assert.deepEqual(row.rtt.sources, ["summary-rtt"]);
+  assert.equal(row.rtt.p50Ms, 1875);
+  assert.deepEqual(row.rtt.sources, ["request-to-observed-message"]);
+  assert.deepEqual(row.discord.samples[0].rttMeasurement, rttMeasurement);
 });
 
 test("imports failed Discord qa-evidence summaries without timing", async () => {

--- a/scripts/import-live-transport-rtt.mjs
+++ b/scripts/import-live-transport-rtt.mjs
@@ -131,6 +131,9 @@ function normalizeEvidenceSummary(value, scenarioId) {
           ...(typeof rttMs === "number" && Number.isFinite(rttMs)
             ? { rttMs: Math.max(0, Math.round(rttMs)) }
             : {}),
+          ...(result.rttMeasurement === undefined
+            ? {}
+            : { rttMeasurement: result.rttMeasurement }),
           ...(typeof result.details === "string" ? { details: result.details } : {}),
         },
       ],

--- a/scripts/import-live-transport-rtt.test.mjs
+++ b/scripts/import-live-transport-rtt.test.mjs
@@ -33,6 +33,7 @@ function modernEvidence({
     { kind: "summary", path: "qa-suite-summary.json", source: "qa-suite" },
     { kind: "report", path: "qa-suite-report.md", source: "qa-suite" },
   ],
+  rttMeasurement,
   status = "pass",
   timing,
   title = "Slack canary echo",
@@ -51,6 +52,7 @@ function modernEvidence({
         result: {
           status,
           ...(timing ? { timing } : {}),
+          ...(rttMeasurement ? { rttMeasurement } : {}),
         },
       },
     ],
@@ -259,6 +261,22 @@ test("imports RTT from the exact modern Slack qa-suite companion shape", async (
 });
 
 test("keeps structured and observed RTT ahead of qa-suite details", async () => {
+  const rttMeasurement = {
+    finalMatchedReplyRttMs: 789,
+    requestStartedAt: "2026-09-03T08:44:50.000Z",
+    responseObservedAt: "2026-09-03T08:44:50.789Z",
+    source: "request-to-observed-message",
+  };
+  const structured = await importModernSlack({
+    evidence: modernEvidence({
+      timing: { rttMs: 456 },
+      rttMeasurement,
+    }),
+  });
+  assert.deepEqual(structured.row.rtt.warmSamples, [789]);
+  assert.deepEqual(structured.row.rtt.sources, ["request-to-observed-message"]);
+  assert.deepEqual(structured.row.samples[0].rttMeasurement, rttMeasurement);
+
   const observed = [
     {
       scenarioId: "slack-canary",
@@ -267,13 +285,6 @@ test("keeps structured and observed RTT ahead of qa-suite details", async () => 
       timestamp: "2026-09-03T08:44:50.777Z",
     },
   ];
-  const structured = await importModernSlack({
-    evidence: modernEvidence({ timing: { rttMs: 456 } }),
-    observed,
-  });
-  assert.deepEqual(structured.row.rtt.warmSamples, [456]);
-  assert.deepEqual(structured.row.rtt.sources, ["summary-rtt"]);
-
   const observedFallback = await importModernSlack({ observed });
   assert.deepEqual(observedFallback.row.rtt.warmSamples, [777]);
   assert.deepEqual(observedFallback.row.rtt.sources, ["observed-message"]);

--- a/scripts/openclaw-qa-harness.mjs
+++ b/scripts/openclaw-qa-harness.mjs
@@ -1,1 +1,1 @@
-export const OPENCLAW_QA_HARNESS_SHA = "84eb1ec03bf237ae2ad0ffacd3804d52c21162bc";
+export const OPENCLAW_QA_HARNESS_SHA = "391ab8b4c7d43300e778c6805acb10128fd8f599";


### PR DESCRIPTION
## What Problem This Solves

Canonical OpenClaw QA evidence can now carry a complete RTT measurement, but the RTT import normalizers discarded that object and fell back to scalar `summary-rtt` provenance.

## Why This Change Was Made

Preserve `result.rttMeasurement` through the Slack/live-transport and Discord evidence normalizers so the existing structured extraction path remains authoritative over conflicting scalar timing or optional observed-message sidecars. Pin the immutable OpenClaw producer repair in the same change.

Producer repair: https://github.com/openclaw/openclaw/pull/137406

## User Impact

New channel qualification rows retain the actual RTT source plus request and response timestamps. Historical timing-only evidence continues to import as `summary-rtt`.

## Evidence

- `npm test`: 161/161 passed
- `npm run check`: all RTT data families validated and README remained stable
- `git diff --check`: clean
- Fresh Sol/high autoreview: no accepted or actionable findings
- Pinned OpenClaw SHA: `391ab8b4c7d43300e778c6805acb10128fd8f599`
