### PR TITLE
fix: historical Slack RTT fails before gateway startup

### DIFF
--- a/.github/workflows/release-channel-rtt.yml
+++ b/.github/workflows/release-channel-rtt.yml
@@ -240,6 +240,15 @@ jobs:
           set -euo pipefail
           time pnpm build
 
+      - name: Link OpenClaw release channel host
+        working-directory: openclaw-rtt
+        shell: bash
+        run: |
+          set -euo pipefail
+          node scripts/link-openclaw-release-channel-host.mjs \
+            ../openclaw \
+            "${{ matrix.package.channel }}"
+
       - name: Run ${{ matrix.package.label }} RTT samples
         id: channel_rtt
         working-directory: openclaw

--- a/scripts/link-openclaw-release-channel-host.mjs
+++ b/scripts/link-openclaw-release-channel-host.mjs
@@ -1,0 +1,91 @@
+import fs from "node:fs/promises";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const HOST_EXPORT = "openclaw/plugin-sdk/channel-outbound";
+
+function usage() {
+  return "Usage: node scripts/link-openclaw-release-channel-host.mjs <openclaw-repo-root> <channel>";
+}
+
+async function existingLinkTarget(linkPath) {
+  let stat;
+  try {
+    stat = await fs.lstat(linkPath);
+  } catch (error) {
+    if (error?.code === "ENOENT") {
+      return undefined;
+    }
+    throw error;
+  }
+  if (!stat.isSymbolicLink()) {
+    throw new Error(`Refusing to replace non-symlink host path: ${linkPath}`);
+  }
+  try {
+    return await fs.realpath(linkPath);
+  } catch (error) {
+    if (error?.code === "ENOENT") {
+      throw new Error(`Refusing broken OpenClaw host link: ${linkPath}`);
+    }
+    throw error;
+  }
+}
+
+export async function linkOpenClawReleaseChannelHost(repoRootInput, channel) {
+  if (!repoRootInput || !/^[a-z0-9][a-z0-9-]*$/u.test(channel ?? "")) {
+    throw new Error(usage());
+  }
+
+  const repoRoot = await fs.realpath(path.resolve(repoRootInput));
+  const channelDir = path.join(repoRoot, "extensions", channel);
+  const channelPackageJson = path.join(channelDir, "package.json");
+  const expectedExport = path.join(repoRoot, "dist", "plugin-sdk", "channel-outbound.js");
+
+  await Promise.all([fs.access(channelPackageJson), fs.access(expectedExport)]);
+
+  const hostLink = path.join(channelDir, "node_modules", "openclaw");
+  const currentTarget = await existingLinkTarget(hostLink);
+  if (currentTarget && currentTarget !== repoRoot) {
+    throw new Error(`Refusing conflicting OpenClaw host link: ${hostLink} -> ${currentTarget}`);
+  }
+
+  const created = currentTarget === undefined;
+  if (created) {
+    await fs.mkdir(path.dirname(hostLink), { recursive: true });
+    await fs.symlink(repoRoot, hostLink, "dir");
+  }
+
+  try {
+    const requireFromChannel = createRequire(channelPackageJson);
+    const resolvedExport = await fs.realpath(requireFromChannel.resolve(HOST_EXPORT));
+    const expectedRealpath = await fs.realpath(expectedExport);
+    if (resolvedExport !== expectedRealpath) {
+      throw new Error(
+        `${HOST_EXPORT} resolved to ${resolvedExport}, expected ${expectedRealpath}`,
+      );
+    }
+  } catch (error) {
+    if (created) {
+      await fs.rm(hostLink, { force: true });
+    }
+    throw error;
+  }
+
+  return { channelDir, created, hostLink, repoRoot };
+}
+
+async function main() {
+  const [repoRoot, channel, ...extra] = process.argv.slice(2);
+  if (extra.length > 0) {
+    throw new Error(usage());
+  }
+  const result = await linkOpenClawReleaseChannelHost(repoRoot, channel);
+  console.log(
+    `${result.created ? "linked" : "verified"} ${result.hostLink} -> ${result.repoRoot}`,
+  );
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  await main();
+}

--- a/scripts/link-openclaw-release-channel-host.test.mjs
+++ b/scripts/link-openclaw-release-channel-host.test.mjs
@@ -1,0 +1,131 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { linkOpenClawReleaseChannelHost } from "./link-openclaw-release-channel-host.mjs";
+
+async function makeFixture({ exportedPath = "./dist/plugin-sdk/channel-outbound.js" } = {}) {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-release-channel-host-"));
+  const channelDir = path.join(root, "extensions", "slack");
+  const exportPath = path.join(root, "dist", "plugin-sdk", "channel-outbound.js");
+  await Promise.all([
+    fs.mkdir(channelDir, { recursive: true }),
+    fs.mkdir(path.dirname(exportPath), { recursive: true }),
+  ]);
+  await Promise.all([
+    fs.writeFile(
+      path.join(root, "package.json"),
+      `${JSON.stringify({
+        name: "openclaw",
+        type: "module",
+        exports: {
+          "./plugin-sdk/channel-outbound": exportedPath,
+        },
+      })}\n`,
+    ),
+    fs.writeFile(path.join(channelDir, "package.json"), '{"name":"@openclaw/slack"}\n'),
+    fs.writeFile(path.join(channelDir, "streaming-compat.ts"), "export const unchanged = true;\n"),
+    fs.writeFile(exportPath, "export const outbound = true;\n"),
+  ]);
+  return { channelDir, exportPath, root };
+}
+
+test("links the selected release channel to the exact release host", async (t) => {
+  const fixture = await makeFixture();
+  t.after(() => fs.rm(fixture.root, { force: true, recursive: true }));
+
+  const sourceBefore = await fs.readFile(
+    path.join(fixture.channelDir, "streaming-compat.ts"),
+    "utf8",
+  );
+  const result = await linkOpenClawReleaseChannelHost(fixture.root, "slack");
+
+  assert.equal(result.created, true);
+  assert.equal(await fs.realpath(result.hostLink), await fs.realpath(fixture.root));
+  assert.equal(
+    await fs.readFile(path.join(fixture.channelDir, "streaming-compat.ts"), "utf8"),
+    sourceBefore,
+  );
+});
+
+test("is idempotent when the exact release host is already linked", async (t) => {
+  const fixture = await makeFixture();
+  t.after(() => fs.rm(fixture.root, { force: true, recursive: true }));
+
+  const first = await linkOpenClawReleaseChannelHost(fixture.root, "slack");
+  const second = await linkOpenClawReleaseChannelHost(fixture.root, "slack");
+
+  assert.equal(first.created, true);
+  assert.equal(second.created, false);
+  assert.equal(second.hostLink, first.hostLink);
+});
+
+test("refuses a non-symlink host path", async (t) => {
+  const fixture = await makeFixture();
+  t.after(() => fs.rm(fixture.root, { force: true, recursive: true }));
+  const hostLink = path.join(fixture.channelDir, "node_modules", "openclaw");
+  await fs.mkdir(hostLink, { recursive: true });
+
+  await assert.rejects(
+    linkOpenClawReleaseChannelHost(fixture.root, "slack"),
+    /Refusing to replace non-symlink host path/u,
+  );
+});
+
+test("refuses a symlink to a different host", async (t) => {
+  const fixture = await makeFixture();
+  const otherRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-other-host-"));
+  t.after(() => Promise.all([
+    fs.rm(fixture.root, { force: true, recursive: true }),
+    fs.rm(otherRoot, { force: true, recursive: true }),
+  ]));
+  const hostLink = path.join(fixture.channelDir, "node_modules", "openclaw");
+  await fs.mkdir(path.dirname(hostLink), { recursive: true });
+  await fs.symlink(otherRoot, hostLink, "dir");
+
+  await assert.rejects(
+    linkOpenClawReleaseChannelHost(fixture.root, "slack"),
+    /Refusing conflicting OpenClaw host link/u,
+  );
+});
+
+test("refuses a broken host symlink", async (t) => {
+  const fixture = await makeFixture();
+  t.after(() => fs.rm(fixture.root, { force: true, recursive: true }));
+  const hostLink = path.join(fixture.channelDir, "node_modules", "openclaw");
+  await fs.mkdir(path.dirname(hostLink), { recursive: true });
+  await fs.symlink(path.join(fixture.root, "missing-host"), hostLink, "dir");
+
+  await assert.rejects(
+    linkOpenClawReleaseChannelHost(fixture.root, "slack"),
+    /Refusing broken OpenClaw host link/u,
+  );
+});
+
+test("rolls back a new link when the host export resolves elsewhere", async (t) => {
+  const fixture = await makeFixture({ exportedPath: "./dist/plugin-sdk/other.js" });
+  t.after(() => fs.rm(fixture.root, { force: true, recursive: true }));
+  await fs.writeFile(
+    path.join(fixture.root, "dist", "plugin-sdk", "other.js"),
+    "export const other = true;\n",
+  );
+  const hostLink = path.join(fixture.channelDir, "node_modules", "openclaw");
+
+  await assert.rejects(
+    linkOpenClawReleaseChannelHost(fixture.root, "slack"),
+    /resolved to .*other\.js, expected .*channel-outbound\.js/u,
+  );
+  await assert.rejects(fs.lstat(hostLink), { code: "ENOENT" });
+});
+
+test("rejects channel paths outside the selected extension", async (t) => {
+  const fixture = await makeFixture();
+  t.after(() => fs.rm(fixture.root, { force: true, recursive: true }));
+
+  await assert.rejects(
+    linkOpenClawReleaseChannelHost(fixture.root, "../slack"),
+    /Usage:/u,
+  );
+});

--- a/scripts/release-workflow-contract.test.mjs
+++ b/scripts/release-workflow-contract.test.mjs
@@ -28,12 +28,26 @@ test("historical surface Chromium install uses the release dependency", async ()
 
 test("historical channel workflow selects and imports a stable QA summary", async () => {
   const workflow = await fs.readFile(new URL("release-channel-rtt.yml", workflowsDir), "utf8");
+  const releaseBuildStep = "      - name: Build OpenClaw release\n";
+  const harnessBuildStep = "      - name: Build OpenClaw QA harness\n";
+  const hostLinkStepName = "Link OpenClaw release channel host";
+  const hostLinkStep = extractStep(workflow, hostLinkStepName);
+  const hostLinkMarker = `      - name: ${hostLinkStepName}\n`;
+  const measureMarker = "      - name: Run ${{ matrix.package.label }} RTT samples\n";
   const measureStep = extractStep(workflow, "Run ${{ matrix.package.label }} RTT samples");
   const prepareStep = extractStep(
     workflow,
     "Prepare ${{ matrix.package.label }} release import artifact",
   );
   const importStep = extractStep(workflow, "Import channel release RTT results");
+
+  assert.ok(workflow.indexOf(releaseBuildStep) < workflow.indexOf(hostLinkMarker));
+  assert.ok(workflow.indexOf(harnessBuildStep) < workflow.indexOf(hostLinkMarker));
+  assert.ok(workflow.indexOf(hostLinkMarker) < workflow.indexOf(measureMarker));
+  assert.match(hostLinkStep, /\bworking-directory:\s*openclaw-rtt\b/u);
+  assert.match(hostLinkStep, /scripts\/link-openclaw-release-channel-host\.mjs/u);
+  assert.match(hostLinkStep, /\.\.\/openclaw/u);
+  assert.match(hostLinkStep, /"\$\{\{ matrix\.package\.channel \}\}"/u);
 
   assert.match(measureStep, /scripts\/select-channel-qa-summary\.mjs/u);
   assert.match(measureStep, /"\$\{?selector_status\}?" -eq 0/u);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where historical Slack release RTT runs would fail before gateway startup when the current QA harness loaded the release channel source and could not resolve its OpenClaw Plugin SDK host.

## Why This Change Was Made

The workflow now creates an untracked, verified `node_modules/openclaw` link inside the selected release channel package after both builds and before measurement. The link targets the exact release checkout, preserving the tagged source and its runtime behavior while restoring normal optional-peer resolution.

The helper refuses conflicting or broken paths and verifies that `openclaw/plugin-sdk/channel-outbound` resolves to the exact release build artifact.

## User Impact

Maintainers can collect historical Slack RTT evidence with the current QA harness without mutating the release under test or recording infrastructure failures as channel regressions.

## Evidence

- Before: https://github.com/openclaw/openclaw-rtt/actions/runs/33779944883
  - `openclaw@2026.7.2-beta.2` failed three samples with `Cannot find module 'openclaw/plugin-sdk/channel-outbound'`.
- `npm test`: 168/168 passed.
- `npm run check`: 427 RTT, 640 Discord, 2381 channel, and 626 surface rows validated.
- `actionlint .github/workflows/release-channel-rtt.yml`
- `git diff --check`
- Fresh Sol/high autoreview: no accepted or actionable findings.
