### PR TITLE
fix: reject QA evidence without authoritative run bounds

### DIFF
--- a/scripts/import-live-transport-rtt.mjs
+++ b/scripts/import-live-transport-rtt.mjs
@@ -104,55 +104,40 @@ function parseRunBounds(startedAt, finishedAt) {
   if (
     !Number.isFinite(startedAtMs) ||
     !Number.isFinite(finishedAtMs) ||
-    finishedAtMs < startedAtMs
+    finishedAtMs <= startedAtMs
   ) {
     return undefined;
   }
   return { finishedAt, finishedAtMs, startedAt, startedAtMs };
 }
 
-async function evidenceRunBounds(value, entry, result, summaryPath) {
-  const generatedAt = requireString(value.generatedAt, "qa evidence generatedAt");
-  const measurement = result.rttMeasurement;
-  const measurementBounds =
-    measurement && typeof measurement === "object" && !Array.isArray(measurement)
-      ? parseRunBounds(measurement.requestStartedAt, measurement.responseObservedAt)
-      : undefined;
-  const fallback = measurementBounds ?? parseRunBounds(generatedAt, generatedAt);
-  const artifactFilename = selectQaSuiteArtifact(entry);
-  if (!artifactFilename) {
-    return fallback;
-  }
-  let suite;
-  try {
-    suite = await readJson(path.join(path.dirname(summaryPath), artifactFilename));
-  } catch (error) {
-    if (error?.code === "ENOENT") {
-      return fallback;
-    }
-    throw error;
-  }
-  const run = suite?.run;
-  return parseRunBounds(run?.startedAt, run?.finishedAt) ?? fallback;
-}
-
 async function normalizeEvidenceSummary(value, scenarioId, summaryPath) {
   if (value?.kind !== "openclaw.qa.evidence-summary") {
     return { summary: value };
   }
+  requireString(value.generatedAt, "qa evidence generatedAt");
   const entries = Array.isArray(value.entries) ? value.entries : [];
   const entry = entries.find((item) => item?.test?.id === scenarioId);
   if (!entry) {
     throw new Error(`qa evidence missing ${scenarioId}.`);
   }
   const result = requireObject(entry.result, `qa evidence ${scenarioId} result`);
-  const runBounds = await evidenceRunBounds(value, entry, result, summaryPath);
+  const companion = await loadQaSuiteCompanion(entry, summaryPath);
+  const runBounds =
+    companion?.runBounds ??
+    parseRunBounds(
+      result.rttMeasurement?.requestStartedAt,
+      result.rttMeasurement?.responseObservedAt,
+    );
+  if (!runBounds) {
+    throw new Error("qa evidence missing authoritative run bounds.");
+  }
   const timing = result.timing;
   const rttMs =
     timing && typeof timing === "object" && !Array.isArray(timing) ? timing.rttMs : undefined;
   const passed = entries.filter((item) => item?.result?.status === "pass").length;
   return {
-    evidenceEntry: entry,
+    companionRttMs: companion?.rttMs,
     summary: {
       startedAt: runBounds.startedAt,
       finishedAt: runBounds.finishedAt,
@@ -319,11 +304,8 @@ function selectQaSuiteArtifact(entry) {
   return artifactPath;
 }
 
-async function extractQaSuiteRtt(evidenceEntry, summaryPath) {
-  if (evidenceEntry?.result?.status !== "pass") {
-    return undefined;
-  }
-  const artifactFilename = selectQaSuiteArtifact(evidenceEntry);
+async function loadQaSuiteCompanion(entry, summaryPath) {
+  const artifactFilename = selectQaSuiteArtifact(entry);
   if (!artifactFilename) {
     return undefined;
   }
@@ -332,21 +314,31 @@ async function extractQaSuiteRtt(evidenceEntry, summaryPath) {
     suite = await readJson(path.join(path.dirname(summaryPath), artifactFilename));
   } catch (error) {
     if (error?.code === "ENOENT") {
-      // Some immutable runs declared the suite artifact but did not upload it.
-      // That leaves timing unprovable, so retain the sample as failed.
       return undefined;
     }
     throw error;
   }
-  const title = evidenceEntry.test?.title;
-  if (typeof title !== "string" || !Array.isArray(suite?.scenarios)) {
-    return undefined;
+  suite = requireObject(suite, "qa-suite summary");
+  if (!Array.isArray(suite.scenarios)) {
+    throw new Error("qa-suite summary scenarios must be an array.");
+  }
+  requireObject(suite.counts, "qa-suite summary counts");
+  const runBounds = parseRunBounds(suite?.run?.startedAt, suite?.run?.finishedAt);
+  if (!runBounds) {
+    throw new Error("qa-suite summary run must form a valid interval.");
+  }
+  if (entry.result?.status !== "pass") {
+    return { runBounds, rttMs: undefined };
+  }
+  const title = entry.test?.title;
+  if (typeof title !== "string") {
+    return { runBounds, rttMs: undefined };
   }
   // Historical suite scenarios expose no stable id. Their exact unique title
   // is the only cross-artifact key; ambiguity must not produce a measurement.
   const scenarios = suite.scenarios.filter((scenario) => scenario?.name === title);
   if (scenarios.length !== 1 || scenarios[0]?.status !== "pass") {
-    return undefined;
+    return { runBounds, rttMs: undefined };
   }
   const steps = Array.isArray(scenarios[0].steps) ? scenarios[0].steps : [];
   const matches = steps.flatMap((step) => {
@@ -360,7 +352,7 @@ async function extractQaSuiteRtt(evidenceEntry, summaryPath) {
     const rttMs = Number(match[1]);
     return Number.isSafeInteger(rttMs) ? [rttMs] : [];
   });
-  return matches.length === 1 ? matches[0] : undefined;
+  return { runBounds, rttMs: matches.length === 1 ? matches[0] : undefined };
 }
 
 async function readResourceMetrics(pathname) {
@@ -441,9 +433,9 @@ async function readSample(entry, index, scenarioId) {
     rttMs = extractObservedRtt(await readJson(path.resolve(entry.observedMessagesPath)), scenarioId);
     rttSource = rttMs === undefined ? undefined : "observed-message";
   }
-  if (rttMs === undefined && normalized.evidenceEntry) {
-    rttMs = await extractQaSuiteRtt(normalized.evidenceEntry, summaryPath);
-    rttSource = rttMs === undefined ? undefined : "qa-suite-details";
+  if (rttMs === undefined && normalized.companionRttMs !== undefined) {
+    rttMs = normalized.companionRttMs;
+    rttSource = "qa-suite-details";
   }
   const resourceMetrics = await readResourceMetrics(entry.resourceMetricsPath);
   const attempts = readAttemptCount(resourceMetrics.attempts);
@@ -507,9 +499,6 @@ async function main() {
   const finishedAtMs = Math.max(...sampleRunBounds.map((bounds) => bounds.finishedAtMs));
   const startedAt = new Date(startedAtMs).toISOString();
   const finishedAt = new Date(finishedAtMs).toISOString();
-  if (finishedAtMs < startedAtMs) {
-    throw new Error("Channel RTT sample timestamps must form a valid run interval.");
-  }
 
   const runId = buildRunId(startedAt, channel.id, scenarioId, args.spec);
   const seen = await existingChannelRunIds(channel.id);

--- a/scripts/import-live-transport-rtt.test.mjs
+++ b/scripts/import-live-transport-rtt.test.mjs
@@ -33,6 +33,7 @@ function modernEvidence({
     { kind: "summary", path: "qa-suite-summary.json", source: "qa-suite" },
     { kind: "report", path: "qa-suite-report.md", source: "qa-suite" },
   ],
+  generatedAt = "2026-09-03T08:44:53.550Z",
   rttMeasurement,
   status = "pass",
   timing,
@@ -41,7 +42,7 @@ function modernEvidence({
   return {
     kind: "openclaw.qa.evidence-summary",
     schemaVersion: 2,
-    generatedAt: "2026-09-03T08:44:53.550Z",
+    generatedAt,
     entries: [
       {
         test: { id: "slack-canary", title },
@@ -83,15 +84,14 @@ function qaSuiteSummary({
   };
 }
 
-async function importModernSlack({
+async function writeModernSample(workspace, sampleName, {
   companion = qaSuiteSummary(),
   companionBytes,
   evidence = modernEvidence(),
   includeCompanion = true,
   observed,
 } = {}) {
-  const workspace = await makeWorkspace();
-  const sampleDir = path.join(workspace, "sample-1");
+  const sampleDir = path.join(workspace, sampleName);
   const summaryPath = path.join(sampleDir, "rtt-summary.json");
   const observedPath = path.join(sampleDir, "slack-qa-observed-messages.json");
   await writeJson(summaryPath, evidence);
@@ -103,8 +103,18 @@ async function importModernSlack({
   if (observed !== undefined) {
     await writeJson(observedPath, observed);
   }
+  return `${summaryPath}\t${observed ? observedPath : ""}`;
+}
+
+async function importModernSlack(options = {}) {
+  const workspace = options.workspace ?? (await makeWorkspace());
+  const samples = options.samples ?? [options];
+  const sampleLines = [];
+  for (let index = 0; index < samples.length; index += 1) {
+    sampleLines.push(await writeModernSample(workspace, `sample-${index + 1}`, samples[index]));
+  }
   const samplesPath = path.join(workspace, "samples.tsv");
-  await fs.writeFile(samplesPath, `${summaryPath}\t${observed ? observedPath : ""}\n`);
+  await fs.writeFile(samplesPath, `${sampleLines.join("\n")}\n`);
   await execFileAsync(
     process.execPath,
     [
@@ -211,47 +221,33 @@ test("imports live transport summary RTT samples", async () => {
   });
 });
 
-test("imports channel qa-evidence summaries", async () => {
+test("rejects timing-only modern evidence without authoritative run bounds", async () => {
   const workspace = await makeWorkspace();
-  const summaryPath = path.join(workspace, "sample-1", "qa-evidence.json");
-  await writeJson(summaryPath, {
-    kind: "openclaw.qa.evidence-summary",
-    schemaVersion: 2,
-    generatedAt: "2026-05-16T00:03:00.000Z",
-    entries: [
-      {
-        test: { id: "slack-canary", title: "Slack canary echo" },
-        execution: { provider: { fixture: "mock-openai" } },
-        result: { status: "pass", timing: { rttMs: 456 } },
-      },
-    ],
-  });
-  const samplesPath = path.join(workspace, "samples.tsv");
-  await fs.writeFile(samplesPath, `${summaryPath}\n`);
-
-  await execFileAsync(
-    process.execPath,
-    [
-      IMPORT_SCRIPT,
-      samplesPath,
-      "--channel",
-      "slack",
-      "--spec",
-      "openclaw@main",
-      "--version",
-      "2026.5.16+qa-evidence",
-      "--provider-mode",
-      "mock-openai",
-    ],
-    { cwd: workspace },
+  await assert.rejects(
+    importModernSlack({
+      workspace,
+      evidence: modernEvidence({
+        artifacts: [],
+        timing: { rttMs: 456 },
+      }),
+      includeCompanion: false,
+    }),
+    /qa evidence missing authoritative run bounds/u,
   );
-
-  const [row] = await readJsonl(
-    path.join(workspace, "data/channels/slack/2026.5.16+qa-evidence.jsonl"),
+  await assert.rejects(
+    fs.stat(path.join(workspace, "data/channels/slack/2026.7.2-beta.2.jsonl")),
+    { code: "ENOENT" },
   );
-  assert.equal(row.run.status, "pass");
-  assert.deepEqual(row.rtt.warmSamples, [456]);
-  assert.deepEqual(row.rtt.sources, ["summary-rtt"]);
+  await assert.rejects(fs.stat(path.join(workspace, "runs/slack")), { code: "ENOENT" });
+});
+
+test("rejects modern evidence with an empty generatedAt", async () => {
+  await assert.rejects(
+    importModernSlack({
+      evidence: modernEvidence({ generatedAt: "" }),
+    }),
+    /qa evidence generatedAt must be a non-empty string/u,
+  );
 });
 
 test("imports RTT from the exact modern Slack qa-suite companion shape", async () => {
@@ -296,25 +292,153 @@ test("keeps structured and observed RTT ahead of qa-suite details", async () => 
   assert.deepEqual(observedFallback.row.rtt.sources, ["observed-message"]);
 });
 
-test("uses structured RTT bounds when a modern evidence companion is unavailable", async () => {
+for (const { name, artifacts } of [
+  { name: "is not declared", artifacts: [] },
+  {
+    name: "is declared but missing",
+    artifacts: [{ kind: "summary", path: "qa-suite-summary.json", source: "qa-suite" }],
+  },
+]) {
+  test(`uses structured RTT bounds when a modern evidence companion ${name}`, async () => {
+    const rttMeasurement = {
+      finalMatchedReplyRttMs: 789,
+      requestStartedAt: "2026-09-03T08:44:50.000Z",
+      responseObservedAt: "2026-09-03T08:44:50.789Z",
+      source: "request-to-observed-message",
+    };
+    const { row } = await importModernSlack({
+      evidence: modernEvidence({
+        artifacts,
+        rttMeasurement,
+        timing: { rttMs: 789 },
+      }),
+      includeCompanion: false,
+    });
+
+    assert.equal(row.run.startedAt, rttMeasurement.requestStartedAt);
+    assert.equal(row.run.finishedAt, rttMeasurement.responseObservedAt);
+    assert.equal(row.run.durationMs, 789);
+  });
+}
+
+test("rejects equal structured RTT bounds without a companion", async () => {
+  const timestamp = "2026-09-03T08:44:50.000Z";
+  await assert.rejects(
+    importModernSlack({
+      evidence: modernEvidence({
+        artifacts: [],
+        rttMeasurement: {
+          finalMatchedReplyRttMs: 1,
+          requestStartedAt: timestamp,
+          responseObservedAt: timestamp,
+          source: "request-to-observed-message",
+        },
+      }),
+      includeCompanion: false,
+    }),
+    /qa evidence missing authoritative run bounds/u,
+  );
+});
+
+test("imports failed modern evidence with valid companion bounds", async () => {
+  const { row } = await importModernSlack({
+    evidence: modernEvidence({ status: "fail" }),
+  });
+
+  assert.equal(row.run.startedAt, "2026-09-03T08:44:40.000Z");
+  assert.equal(row.run.finishedAt, "2026-09-03T08:44:53.550Z");
+  assert.equal(row.run.durationMs, 13_550);
+  assert.equal(row.run.status, "fail");
+  assert.deepEqual(row.rtt.warmSamples, []);
+});
+
+test("rejects a non-suite companion with parseable run bounds", async () => {
+  const workspace = await makeWorkspace();
+  await assert.rejects(
+    importModernSlack({
+      workspace,
+      companion: {
+        run: {
+          startedAt: "2026-09-03T08:44:40.000Z",
+          finishedAt: "2026-09-03T08:44:53.550Z",
+        },
+      },
+    }),
+    /qa-suite summary scenarios must be an array/u,
+  );
+  await assert.rejects(
+    fs.stat(path.join(workspace, "data/channels/slack/2026.7.2-beta.2.jsonl")),
+    { code: "ENOENT" },
+  );
+});
+
+for (const { name, run } of [
+  { name: "missing", run: undefined },
+  {
+    name: "unparseable",
+    run: {
+      startedAt: "not-a-date",
+      finishedAt: "2026-09-03T08:44:53.550Z",
+    },
+  },
+  {
+    name: "reversed",
+    run: {
+      startedAt: "2026-09-03T08:44:53.550Z",
+      finishedAt: "2026-09-03T08:44:40.000Z",
+    },
+  },
+  {
+    name: "equal",
+    run: {
+      startedAt: "2026-09-03T08:44:53.550Z",
+      finishedAt: "2026-09-03T08:44:53.550Z",
+    },
+  },
+]) {
+  test(`rejects a modern evidence companion with ${name} run bounds`, async () => {
+    const companion = qaSuiteSummary();
+    if (run === undefined) {
+      delete companion.run;
+    } else {
+      companion.run = run;
+    }
+    await assert.rejects(
+      importModernSlack({ companion }),
+      /qa-suite summary run must form a valid interval/u,
+    );
+  });
+}
+
+test("aggregates modern evidence bounds independent of sample order", async () => {
   const rttMeasurement = {
-    finalMatchedReplyRttMs: 789,
-    requestStartedAt: "2026-09-03T08:44:50.000Z",
-    responseObservedAt: "2026-09-03T08:44:50.789Z",
+    finalMatchedReplyRttMs: 3000,
+    requestStartedAt: "2026-09-03T08:45:10.000Z",
+    responseObservedAt: "2026-09-03T08:45:13.000Z",
     source: "request-to-observed-message",
   };
   const { row } = await importModernSlack({
-    evidence: modernEvidence({
-      artifacts: [],
-      rttMeasurement,
-      timing: { rttMs: 789 },
-    }),
-    includeCompanion: false,
+    samples: [
+      {
+        companion: qaSuiteSummary({
+          startedAt: "2026-09-03T08:45:00.000Z",
+          finishedAt: "2026-09-03T08:45:14.000Z",
+        }),
+        evidence: modernEvidence({ rttMeasurement }),
+      },
+      {
+        companion: qaSuiteSummary({
+          startedAt: "2026-09-03T08:44:40.000Z",
+          finishedAt: "2026-09-03T08:44:53.550Z",
+        }),
+      },
+    ],
   });
 
-  assert.equal(row.run.startedAt, rttMeasurement.requestStartedAt);
-  assert.equal(row.run.finishedAt, rttMeasurement.responseObservedAt);
-  assert.equal(row.run.durationMs, 789);
+  assert.equal(row.run.startedAt, "2026-09-03T08:44:40.000Z");
+  assert.equal(row.run.finishedAt, "2026-09-03T08:45:14.000Z");
+  assert.equal(row.run.durationMs, 34_000);
+  assert.deepEqual(row.rtt.warmSamples, [3000, 2857]);
 });
 
 for (const {
@@ -326,10 +450,6 @@ for (const {
   {
     name: "wrong suite scenario title",
     companion: qaSuiteSummary({ scenarioName: "Another scenario" }),
-  },
-  {
-    name: "failed evidence",
-    evidence: modernEvidence({ status: "fail" }),
   },
   {
     name: "failed suite scenario",
@@ -375,10 +495,6 @@ for (const {
         },
       ],
     }),
-  },
-  {
-    name: "missing suite companion",
-    includeCompanion: false,
   },
 ]) {
   test(`imports a failed sample for ${name}`, async () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where importing modern QA evidence could record a zero-duration
run when authoritative lifecycle bounds were absent, and could silently accept
a malformed declared QA suite run interval.

## Why This Change Was Made

The importer now loads the selected QA suite companion once and treats its
validated run interval as authoritative. When the companion is unavailable,
only a valid structured RTT measurement may supply lifecycle bounds; malformed
companions and evidence without either source fail before any data is written.

RTT value precedence remains unchanged: structured measurement, summary timing,
observed messages, then companion details.

## User Impact

Published RTT rows retain authoritative lifecycle timestamps. Invalid or
incomplete modern QA evidence fails explicitly instead of producing a
misleading `durationMs=0` row.

## Evidence

- Base: `4a4d911bf006bf68ae7fa9edd94b849039668e9d`
- Head: `442d8f23444834d454dafb0b93816a61ab703a22`
- Pre-fix focused regression: 21 passed, 4 failed. The failures proved that
  timing-only evidence and missing, unparseable, or reversed companion run
  bounds were incorrectly accepted.
- Review regression: a non-suite JSON object with parseable timestamps was
  accepted before the strict companion-shape check and is now rejected before
  writes.
- Curie regressions: equal companion bounds, equal structured measurement
  bounds, and an empty `generatedAt` each reproduced as an accepted import
  before the fix and now fail explicitly. `generatedAt` is validated as
  evidence metadata but is never used as lifecycle timing.
- Post-fix focused regression:
  `node --test scripts/import-live-transport-rtt.test.mjs` - 29 passed.
- Full test suite: `npm test` - 170 passed.
- `npm run check`, `npm run validate`, `actionlint .github/workflows/*.yml`,
  and `git diff --check` passed. Validation covered 429 RTT, 641 Discord RTT,
  2,388 channel RTT, and 628 surface RTT rows; generated README parity was
  clean.
- Production delta: 35 additions, 46 deletions, net -11 lines.
- Test delta: 179 additions, 63 deletions, net +116 lines.
- Exact-head hosted `Scripts`, `Actionlint`, and CodeQL checks passed.
- Autoreview's suggestion to parse `generatedAt` as a timestamp was not
  applied: the OpenClaw evidence schema and RTT selector intentionally require
  only a non-empty string. The field remains validation-only and is never used
  as lifecycle timing.
- Final Curie review found no issues on exact head
  `442d8f23444834d454dafb0b93816a61ab703a22`.
- ClawSweeper re-review is queued with no published actionable finding; policy
  does not block landing on the publisher.

Related: https://github.com/openclaw/openclaw-rtt/pull/63
