### PR TITLE
fix: preserve Discord RTT lifecycle bounds

### DIFF
--- a/scripts/import-discord-rtt.mjs
+++ b/scripts/import-discord-rtt.mjs
@@ -204,38 +204,38 @@ function extractCanaryRtt(observedMessages) {
   return Number.isFinite(rttMs) ? rttMs : undefined;
 }
 
-function extractSummaryDurationRtt(summary) {
-  const startedAtMs = Date.parse(summary.startedAt);
-  const finishedAtMs = Date.parse(summary.finishedAt);
-  if (!Number.isFinite(startedAtMs) || !Number.isFinite(finishedAtMs)) {
-    return undefined;
+function parseRunBounds(startedAt, finishedAt, positive = false) {
+  const startedAtMs = Date.parse(startedAt);
+  const finishedAtMs = Date.parse(finishedAt);
+  if (!Number.isFinite(startedAtMs) || !Number.isFinite(finishedAtMs) || (positive && finishedAtMs <= startedAtMs)) {
+    throw new Error(positive
+      ? "discord-canary rttMeasurement must define a positive parseable interval."
+      : "Discord RTT sample timestamps must be parseable.");
   }
-  const rttMs = Math.max(0, Math.round(finishedAtMs - startedAtMs));
-  return Number.isFinite(rttMs) ? rttMs : undefined;
+  return { startedAtMs, finishedAtMs, durationMs: Math.max(0, finishedAtMs - startedAtMs) };
 }
 
 function extractScenarioMeasurement(scenario) {
   const measurement = scenario?.rttMeasurement;
-  if (typeof measurement !== "object" || measurement === null || Array.isArray(measurement)) {
+  if (measurement === undefined) {
     return undefined;
   }
-  const finalMatchedReplyRttMs = measurement.finalMatchedReplyRttMs;
-  if (typeof finalMatchedReplyRttMs !== "number" || !Number.isFinite(finalMatchedReplyRttMs)) {
-    return undefined;
-  }
+  requireObject(measurement, "discord-canary rttMeasurement");
+  const finalMatchedReplyRttMs = requireNumber(measurement.finalMatchedReplyRttMs, "discord-canary rttMeasurement.finalMatchedReplyRttMs");
+  const requestStartedAt = requireString(measurement.requestStartedAt, "discord-canary rttMeasurement.requestStartedAt");
+  const responseObservedAt = requireString(measurement.responseObservedAt, "discord-canary rttMeasurement.responseObservedAt");
   const source =
     typeof measurement.source === "string" && measurement.source.trim()
       ? measurement.source
       : "request-to-observed-message";
   return {
-    finalMatchedReplyRttMs: Math.max(0, Math.round(finalMatchedReplyRttMs)),
-    ...(typeof measurement.requestStartedAt === "string"
-      ? { requestStartedAt: measurement.requestStartedAt }
-      : {}),
-    ...(typeof measurement.responseObservedAt === "string"
-      ? { responseObservedAt: measurement.responseObservedAt }
-      : {}),
-    source,
+    measurement: {
+      finalMatchedReplyRttMs: Math.max(0, Math.round(finalMatchedReplyRttMs)),
+      requestStartedAt,
+      responseObservedAt,
+      source,
+    },
+    runBounds: parseRunBounds(requestStartedAt, responseObservedAt, true),
   };
 }
 
@@ -276,7 +276,10 @@ async function readSample(entry, index) {
     ? await readResourceMetrics(path.resolve(entry.resourceMetricsPath))
     : undefined;
   const scenario = summary.scenarios.find((item) => item?.id === "discord-canary");
-  const rttMeasurement = extractScenarioMeasurement(scenario);
+  const extractedMeasurement = extractScenarioMeasurement(scenario);
+  const rttMeasurement = extractedMeasurement?.measurement;
+  const runBounds =
+    extractedMeasurement?.runBounds ?? parseRunBounds(summary.startedAt, summary.finishedAt);
   const summaryRttMs = extractSummaryScenarioRtt(scenario);
   const observedRttMs = extractCanaryRtt(observedMessages);
   const rttMs = rttMeasurement?.finalMatchedReplyRttMs ?? summaryRttMs ?? observedRttMs;
@@ -290,12 +293,14 @@ async function readSample(entry, index) {
   return {
     index,
     summary,
+    runBounds,
     status: scenario?.status === "pass" && rttMs !== undefined ? "pass" : "fail",
     rttMs,
     rttSource,
     rttMeasurement,
     details: scenario?.details,
-    durationRttMs: scenario?.status === "pass" ? extractSummaryDurationRtt(summary) : undefined,
+    durationRttMs:
+      rttMeasurement || scenario?.status === "pass" ? runBounds.durationMs : undefined,
     resources: {
       ...(resources ?? {}),
       ...extractGatewayResourceMetrics(summary),
@@ -318,13 +323,10 @@ async function main() {
   for (let index = 0; index < entries.length; index += 1) {
     samples.push(await readSample(entries[index], index + 1));
   }
-  const startedAt = samples[0].summary.startedAt;
-  const finishedAt = samples.at(-1).summary.finishedAt;
-  const startedAtMs = Date.parse(startedAt);
-  const finishedAtMs = Date.parse(finishedAt);
-  if (!Number.isFinite(startedAtMs) || !Number.isFinite(finishedAtMs)) {
-    throw new Error("Discord RTT sample timestamps must be parseable.");
-  }
+  const startedAtMs = Math.min(...samples.map((sample) => sample.runBounds.startedAtMs));
+  const finishedAtMs = Math.max(...samples.map((sample) => sample.runBounds.finishedAtMs));
+  const startedAt = new Date(startedAtMs).toISOString();
+  const finishedAt = new Date(finishedAtMs).toISOString();
 
   const runId = buildRunId(startedAt, args.spec);
   const seen = await existingRunIds();

--- a/scripts/import-discord-rtt.test.mjs
+++ b/scripts/import-discord-rtt.test.mjs
@@ -15,6 +15,57 @@ async function makeWorkspace() {
   return await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-rtt-discord-import-test-"));
 }
 
+async function writeEvidenceSamples(workspace, samples) {
+  const samplePaths = [];
+  for (const [index, sample] of samples.entries()) {
+    const sampleDir = path.join(workspace, `sample-${index + 1}`);
+    const summaryPath = path.join(sampleDir, "qa-evidence.json");
+    await fs.mkdir(sampleDir, { recursive: true });
+    await fs.writeFile(
+      summaryPath,
+      `${JSON.stringify({
+        kind: "openclaw.qa.evidence-summary",
+        schemaVersion: 2,
+        generatedAt: sample.generatedAt,
+        entries: [
+          {
+            test: { id: "discord-canary", title: "Discord canary echo" },
+            execution: { provider: { fixture: "mock-openai" } },
+            result: sample.result,
+          },
+        ],
+      })}\n`,
+    );
+    samplePaths.push(`${summaryPath}\t\t`);
+  }
+  const samplesPath = path.join(workspace, "samples.tsv");
+  await fs.writeFile(samplesPath, `${samplePaths.join("\n")}\n`);
+  return samplesPath;
+}
+
+async function importEvidenceSamples(workspace, samples, { spec, version, requirePass = false }) {
+  const args = [
+    IMPORT_SCRIPT,
+    await writeEvidenceSamples(workspace, samples),
+    "--spec",
+    spec,
+    "--version",
+    version,
+  ];
+  if (requirePass) {
+    args.push("--require-pass");
+  }
+  return await execFileAsync(process.execPath, args, { cwd: workspace });
+}
+
+async function readDiscordRow(workspace, version) {
+  const rows = await fs.readFile(
+    path.join(workspace, `data/channels/discord/${version}.jsonl`),
+    "utf8",
+  );
+  return JSON.parse(rows.trim());
+}
+
 test("does not write failed Discord runs when pass is required", async () => {
   const workspace = await makeWorkspace();
   const sampleDir = path.join(workspace, "sample-1");
@@ -98,9 +149,11 @@ test("imports Discord qa-evidence summaries", async () => {
     .split("\n")
     .map((line) => JSON.parse(line));
   assert.equal(row.run.status, "pass");
+  assert.equal(row.run.durationMs, 0);
   assert.equal(row.rtt.p50Ms, 1903);
   assert.deepEqual(row.rtt.sources, ["summary-rtt"]);
   assert.equal(row.mode.providerMode, "mock-openai");
+  assert.equal(row.discord.samples[0].durationRttMs, 0);
 });
 
 test("preserves Discord qa-evidence RTT measurement without the retired sidecar", async () => {
@@ -155,9 +208,13 @@ test("preserves Discord qa-evidence RTT measurement without the retired sidecar"
     .split("\n")
     .map((line) => JSON.parse(line));
   assert.equal(row.run.status, "pass");
+  assert.equal(row.run.startedAt, rttMeasurement.requestStartedAt);
+  assert.equal(row.run.finishedAt, rttMeasurement.responseObservedAt);
+  assert.equal(row.run.durationMs, 1875);
   assert.equal(row.rtt.p50Ms, 1875);
   assert.deepEqual(row.rtt.sources, ["request-to-observed-message"]);
   assert.deepEqual(row.discord.samples[0].rttMeasurement, rttMeasurement);
+  assert.equal(row.discord.samples[0].durationRttMs, 1875);
 });
 
 test("imports failed Discord qa-evidence summaries without timing", async () => {
@@ -207,9 +264,152 @@ test("imports failed Discord qa-evidence summaries without timing", async () => 
     .split("\n")
     .map((line) => JSON.parse(line));
   assert.equal(row.run.status, "fail");
+  assert.equal(row.run.durationMs, 0);
   assert.deepEqual(row.rtt.warmSamples, []);
   assert.equal(row.rtt.failedSamples, 1);
   assert.equal(row.discord.samples[0].details, "timed out after 45000ms waiting for Discord message");
+  assert.equal(row.discord.samples[0].durationRttMs, undefined);
+});
+
+test("imports failed structured Discord evidence with authoritative lifecycle bounds", async () => {
+  const workspace = await makeWorkspace();
+  const rttMeasurement = {
+    finalMatchedReplyRttMs: 2250,
+    requestStartedAt: "2026-07-18T04:00:00.000Z",
+    responseObservedAt: "2026-07-18T04:00:02.250Z",
+    source: "request-to-observed-message",
+  };
+  await importEvidenceSamples(
+    workspace,
+    [
+      {
+        generatedAt: "2026-07-18T04:00:03.000Z",
+        result: {
+          status: "fail",
+          rttMeasurement,
+          failure: { reason: "reply failed a later assertion" },
+        },
+      },
+    ],
+    { spec: "openclaw@2026.7.2", version: "2026.7.2" },
+  );
+
+  const row = await readDiscordRow(workspace, "2026.7.2");
+  assert.equal(row.run.status, "fail");
+  assert.equal(row.run.startedAt, rttMeasurement.requestStartedAt);
+  assert.equal(row.run.finishedAt, rttMeasurement.responseObservedAt);
+  assert.equal(row.run.durationMs, 2250);
+  assert.deepEqual(row.rtt.warmSamples, []);
+  assert.deepEqual(row.rtt.sources, []);
+  assert.equal(row.rtt.failedSamples, 1);
+  assert.equal(row.discord.samples[0].durationRttMs, 2250);
+  assert.deepEqual(row.discord.samples[0].rttMeasurement, rttMeasurement);
+});
+
+test("rejects malformed structured Discord measurement bounds", async (t) => {
+  const cases = [
+    {
+      name: "null",
+      rttMeasurement: null,
+      error: /discord-canary rttMeasurement must be an object/u,
+    },
+    {
+      name: "malformed",
+      rttMeasurement: {
+        finalMatchedReplyRttMs: 1000,
+        requestStartedAt: "not-a-timestamp",
+        responseObservedAt: "2026-07-18T04:00:01.000Z",
+      },
+      error: /must define a positive parseable interval/u,
+    },
+    {
+      name: "partial",
+      rttMeasurement: {
+        finalMatchedReplyRttMs: 1000,
+        requestStartedAt: "2026-07-18T04:00:00.000Z",
+      },
+      error: /responseObservedAt must be a non-empty string/u,
+    },
+    {
+      name: "equal",
+      rttMeasurement: {
+        finalMatchedReplyRttMs: 1000,
+        requestStartedAt: "2026-07-18T04:00:00.000Z",
+        responseObservedAt: "2026-07-18T04:00:00.000Z",
+      },
+      error: /must define a positive parseable interval/u,
+    },
+    {
+      name: "reversed",
+      rttMeasurement: {
+        finalMatchedReplyRttMs: 1000,
+        requestStartedAt: "2026-07-18T04:00:01.000Z",
+        responseObservedAt: "2026-07-18T04:00:00.000Z",
+      },
+      error: /must define a positive parseable interval/u,
+    },
+  ];
+  for (const entry of cases) {
+    await t.test(entry.name, async () => {
+      const workspace = await makeWorkspace();
+      await assert.rejects(
+        importEvidenceSamples(
+          workspace,
+          [
+            {
+              generatedAt: "2026-07-18T04:00:02.000Z",
+              result: {
+                status: "pass",
+                timing: { rttMs: 1000 },
+                rttMeasurement: entry.rttMeasurement,
+              },
+            },
+          ],
+          { spec: "openclaw@main", version: "2026.7.2+invalid", requirePass: true },
+        ),
+        entry.error,
+      );
+      await assert.rejects(fs.stat(path.join(workspace, "runs/discord")), { code: "ENOENT" });
+    });
+  }
+});
+
+test("aggregates structured Discord lifecycle bounds independent of sample order", async () => {
+  const workspace = await makeWorkspace();
+  await importEvidenceSamples(
+    workspace,
+    [
+      {
+        generatedAt: "2026-07-18T04:00:23.000Z",
+        result: {
+          status: "pass",
+          rttMeasurement: {
+            finalMatchedReplyRttMs: 2000,
+            requestStartedAt: "2026-07-18T04:00:20.000Z",
+            responseObservedAt: "2026-07-18T04:00:22.000Z",
+          },
+        },
+      },
+      {
+        generatedAt: "2026-07-18T04:00:12.000Z",
+        result: {
+          status: "pass",
+          rttMeasurement: {
+            finalMatchedReplyRttMs: 1500,
+            requestStartedAt: "2026-07-18T04:00:10.000Z",
+            responseObservedAt: "2026-07-18T04:00:11.500Z",
+          },
+        },
+      },
+    ],
+    { spec: "openclaw@main", version: "2026.7.2+reverse", requirePass: true },
+  );
+
+  const row = await readDiscordRow(workspace, "2026.7.2+reverse");
+  assert.equal(row.run.startedAt, "2026-07-18T04:00:10.000Z");
+  assert.equal(row.run.finishedAt, "2026-07-18T04:00:22.000Z");
+  assert.equal(row.run.durationMs, 12000);
+  assert.deepEqual(row.discord.samples.map((sample) => sample.durationRttMs), [2000, 1500]);
 });
 
 test("imports Discord resource metrics without changing RTT stats", async () => {
@@ -339,7 +539,7 @@ test("prefers Discord structured RTT measurement over legacy fallbacks", async (
 
   const result = JSON.parse(
     await fs.readFile(
-      path.join(workspace, "runs/discord/2026-05-16T000000000Z-openclaw_2026.5.17-discord-rtt/result.json"),
+      path.join(workspace, "runs/discord/2026-05-16T000010000Z-openclaw_2026.5.17-discord-rtt/result.json"),
       "utf8",
     ),
   );
@@ -352,7 +552,7 @@ test("prefers Discord structured RTT measurement over legacy fallbacks", async (
     responseObservedAt: "2026-05-16T00:00:16.789Z",
     source: "request-to-observed-message",
   });
-  assert.equal(result.discord.samples[0].durationRttMs, 45000);
+  assert.equal(result.discord.samples[0].durationRttMs, 6789);
 });
 
 test("does not treat Discord whole-command duration as RTT", async () => {


### PR DESCRIPTION
## Summary

- use declared Discord `rttMeasurement` timestamps as authoritative lifecycle bounds
- reject null, malformed, partial, equal, or reversed structured measurements
- aggregate multi-sample lifecycle bounds by earliest start and latest finish, independent of input order
- keep failed structured measurements out of RTT warm samples while retaining their lifecycle evidence

## Root cause

The Discord importer preserved structured RTT values but normalized modern evidence lifecycle timestamps to `generatedAt`. A valid one-sample measurement could therefore produce `durationMs: 0`, and multi-sample lifecycle duration depended on sample order.

## Verification

- pre-fix focused regression failed on generated-at lifecycle bounds and command-duration `durationRttMs`
- `node --test scripts/import-discord-rtt.test.mjs` (15 passed)
- `npm test` (178 passed)
- `npm run check`
- `npm run validate`
- `git diff --check`
- parity audit: 4090 rows, 4090 artifacts, 0 duplicate IDs, 0 duplicate artifact refs, 0 missing artifacts, 0 orphan artifacts, 0 mismatched artifact IDs, 0 synthetic rows
- autoreview: clean, no accepted or actionable findings
- independent Curie exact-head review: clean at `07113697de8af54a66639fa64a53e43dfa0d3627`
- hosted CI: all required checks green at the exact head (`33799666381`, `33799666274`)
- ClawSweeper review requested; no review was published before landing, which is non-blocking under repository policy

Production delta: +2 lines (`31` added, `29` removed). Test delta: +200 lines.

The existing scheduled Discord 2026.9.1 run 33792734291 remains untouched; no duplicate proof was dispatched.

## Review status

- [x] local focused and full validation
- [x] autoreview
- [x] hosted CI
- [x] independent exact-head review
- [x] ClawSweeper requested; unpublished and non-blocking
