### PR TITLE
fix(ci): isolate surface RTT publication

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -12,6 +12,9 @@ paths:
   .github/workflows/main-channel-rtt.yml:
     ignore:
       - '^unexpected key "queue" for "concurrency" section\. expected one of "cancel-in-progress", "group"$'
+  .github/workflows/main-surface-rtt.yml:
+    ignore:
+      - '^unexpected key "queue" for "concurrency" section\. expected one of "cancel-in-progress", "group"$'
   .github/workflows/release-channel-rtt.yml:
     ignore:
       - '^unexpected key "queue" for "concurrency" section\. expected one of "cancel-in-progress", "group"$'

--- a/.github/workflows/main-surface-rtt.yml
+++ b/.github/workflows/main-surface-rtt.yml
@@ -29,7 +29,7 @@ on:
 
 permissions:
   actions: read
-  contents: write
+  contents: read
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
@@ -39,10 +39,13 @@ env:
   SURFACE_RTT_PR_SAMPLES: "3"
 
 jobs:
-  measure-surface-rtt:
+  measure:
     name: Measure OpenClaw main surface RTT
     runs-on: blacksmith-16vcpu-ubuntu-2404
     timeout-minutes: 45
+    outputs:
+      artifact_id: ${{ steps.upload_import.outputs.artifact-id }}
+      version: ${{ steps.openclaw_ref.outputs.version }}
     concurrency:
       group: surface-rtt-measure-main-${{ github.ref }}
       cancel-in-progress: ${{ github.event_name == 'pull_request' }}
@@ -52,6 +55,7 @@ jobs:
         with:
           path: openclaw-rtt
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Archive workflow scripts
         working-directory: openclaw-rtt
@@ -78,14 +82,6 @@ jobs:
           runtime: node@${{ env.NODE_VERSION }}
           install: false
 
-      - name: Refresh RTT tracker
-        if: github.event_name != 'pull_request'
-        working-directory: openclaw-rtt
-        shell: bash
-        run: |
-          set -euo pipefail
-          git pull --rebase origin main
-
       - name: Locate pnpm store
         id: pnpm-store
         working-directory: openclaw
@@ -111,13 +107,6 @@ jobs:
           set -euo pipefail
           time pnpm install --frozen-lockfile --prefer-offline --config.engine-strict=false --config.enable-pre-post-scripts=true --config.side-effects-cache=true
 
-      - name: Install Playwright Chromium
-        working-directory: openclaw
-        shell: bash
-        run: |
-          set -euo pipefail
-          node --import tsx scripts/ensure-playwright-chromium.mts
-
       - name: Resolve OpenClaw ref
         id: openclaw_ref
         working-directory: openclaw
@@ -127,6 +116,20 @@ jobs:
           version="$(node -p "require('./package.json').version")"
           revision="$(git rev-parse --short=10 HEAD)"
           echo "version=${version}+${revision}" >>"$GITHUB_OUTPUT"
+
+      - name: Build OpenClaw CI artifacts
+        working-directory: openclaw
+        shell: bash
+        run: |
+          set -euo pipefail
+          pnpm build:ci-artifacts
+
+      - name: Install Playwright Chromium
+        working-directory: openclaw
+        shell: bash
+        run: |
+          set -euo pipefail
+          node --import tsx scripts/ensure-playwright-chromium.mts
 
       - name: Run RPC RTT samples
         id: rpc_surface_rtt
@@ -178,22 +181,6 @@ jobs:
           path: openclaw/${{ steps.rpc_surface_rtt.outputs.output_root }}
           if-no-files-found: ignore
           retention-days: 14
-
-      - name: Import RPC Surface RTT
-        id: import_rpc_surface_rtt
-        if: steps.rpc_surface_rtt.outcome == 'success'
-        working-directory: openclaw-rtt
-        shell: bash
-        run: |
-          set -euo pipefail
-          node "$RTT_SCRIPTS_DIR/import-surface-rtt.mjs" \
-            "${{ steps.rpc_surface_rtt.outputs.sample_paths }}" \
-            --surface rpc \
-            --spec openclaw@main \
-            --version "${{ steps.openclaw_ref.outputs.version }}" \
-            --provider-mode gateway-rpc \
-            --scenario rpc-gateway-smoke \
-            --require-pass
 
       - name: Run Control UI RTT samples
         id: surface_rtt
@@ -250,6 +237,51 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
 
+      - name: Prepare main surface import artifact
+        if: always() && (steps.rpc_surface_rtt.outcome == 'success' || steps.surface_rtt.outcome == 'success')
+        working-directory: openclaw
+        env:
+          BUNDLE_DIR: ${{ runner.temp }}/main-surface-rtt-import-v1
+          CONTROL_UI_COMPLETE: ${{ steps.surface_rtt.outcome == 'success' }}
+          RPC_COMPLETE: ${{ steps.rpc_surface_rtt.outcome == 'success' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -rf "$BUNDLE_DIR"
+          mkdir -p "$BUNDLE_DIR"
+          if [[ "$RPC_COMPLETE" == "true" ]]; then
+            cp -R "${{ steps.rpc_surface_rtt.outputs.output_root }}" "$BUNDLE_DIR/rpc"
+          fi
+          if [[ "$CONTROL_UI_COMPLETE" == "true" ]]; then
+            cp -R "${{ steps.surface_rtt.outputs.output_root }}" "$BUNDLE_DIR/control-ui"
+          fi
+
+      - name: Upload main surface import artifact
+        id: upload_import
+        if: always() && (steps.rpc_surface_rtt.outcome == 'success' || steps.surface_rtt.outcome == 'success')
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: main-surface-rtt-import-v1-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/main-surface-rtt-import-v1
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Import RPC Surface RTT
+        id: import_rpc_surface_rtt
+        if: steps.rpc_surface_rtt.outcome == 'success'
+        working-directory: openclaw-rtt
+        shell: bash
+        run: |
+          set -euo pipefail
+          node "$RTT_SCRIPTS_DIR/import-surface-rtt.mjs" \
+            "${{ steps.rpc_surface_rtt.outputs.sample_paths }}" \
+            --surface rpc \
+            --spec openclaw@main \
+            --version "${{ steps.openclaw_ref.outputs.version }}" \
+            --provider-mode gateway-rpc \
+            --scenario rpc-gateway-smoke \
+            --require-pass
+
       - name: Import Control UI Surface RTT
         id: import_control_ui_surface_rtt
         if: steps.surface_rtt.outcome == 'success'
@@ -265,7 +297,7 @@ jobs:
             --provider-mode mock-openai \
             --require-pass
 
-      - name: Update Surface Dashboard
+      - name: Validate Surface RTT imports
         if: always() && (steps.import_rpc_surface_rtt.outcome == 'success' || steps.import_control_ui_surface_rtt.outcome == 'success')
         working-directory: openclaw-rtt
         shell: bash
@@ -275,9 +307,124 @@ jobs:
           node "$RTT_SCRIPTS_DIR/validate.mjs"
           node "$RTT_SCRIPTS_DIR/surface-rtt-summary.mjs"
 
+      - name: Fail on Surface RTT errors
+        if: always() && (steps.rpc_surface_rtt.outcome == 'failure' || steps.surface_rtt.outcome == 'failure' || steps.import_rpc_surface_rtt.outcome == 'failure' || steps.import_control_ui_surface_rtt.outcome == 'failure')
+        shell: bash
+        run: |
+          echo "RPC samples: ${{ steps.rpc_surface_rtt.outcome }}"
+          echo "Control UI samples: ${{ steps.surface_rtt.outcome }}"
+          echo "RPC import: ${{ steps.import_rpc_surface_rtt.outcome }}"
+          echo "Control UI import: ${{ steps.import_control_ui_surface_rtt.outcome }}"
+          exit 1
+
+  report:
+    name: Import main surface RTT report
+    needs: measure
+    if: always() && github.event_name != 'pull_request'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      actions: read
+      contents: write
+    concurrency:
+      group: rtt-report-writer-${{ github.ref }}
+      cancel-in-progress: false
+      queue: max
+    steps:
+      - name: Checkout RTT tracker
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Archive workflow scripts
+        shell: bash
+        run: |
+          set -euo pipefail
+          scripts_archive_dir="$(mktemp -d "$RUNNER_TEMP/rtt-workflow-scripts.XXXXXX")"
+          git archive "${{ github.workflow_sha }}" scripts | tar -x -C "$scripts_archive_dir"
+          printf 'RTT_SCRIPTS_DIR=%s\n' "$scripts_archive_dir/scripts" >>"$GITHUB_ENV"
+
+      - name: Setup Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Download main surface import artifact
+        id: download_import
+        if: needs.measure.outputs.artifact_id != ''
+        continue-on-error: true
+        uses: actions/download-artifact@v8.0.1
+        with:
+          artifact-ids: ${{ needs.measure.outputs.artifact_id }}
+          path: ${{ runner.temp }}/main-surface-rtt-import-v1
+          merge-multiple: true
+
+      - name: Refresh RTT tracker
+        id: refresh_tracker
+        if: always() && needs.measure.outputs.artifact_id != '' && steps.download_import.outcome == 'success'
+        shell: bash
+        run: |
+          set -euo pipefail
+          git pull --rebase origin main
+
+      - name: Import main RPC Surface RTT
+        id: import_rpc_surface_rtt
+        if: always() && needs.measure.outputs.artifact_id != '' && steps.download_import.outcome == 'success' && steps.refresh_tracker.outcome == 'success'
+        continue-on-error: true
+        env:
+          VERSION: ${{ needs.measure.outputs.version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          artifact_root="$RUNNER_TEMP/main-surface-rtt-import-v1/rpc"
+          if [[ ! -d "$artifact_root" ]]; then
+            echo "Missing expected RPC artifact root: $artifact_root" >&2
+            exit 1
+          fi
+          node "$RTT_SCRIPTS_DIR/import-surface-rtt.mjs" \
+            --artifact-root "$artifact_root" \
+            --surface rpc \
+            --spec openclaw@main \
+            --version "$VERSION" \
+            --provider-mode gateway-rpc \
+            --scenario rpc-gateway-smoke \
+            --require-pass
+
+      - name: Import main Control UI Surface RTT
+        id: import_control_ui_surface_rtt
+        if: always() && needs.measure.outputs.artifact_id != '' && steps.download_import.outcome == 'success' && steps.refresh_tracker.outcome == 'success'
+        continue-on-error: true
+        env:
+          VERSION: ${{ needs.measure.outputs.version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          artifact_root="$RUNNER_TEMP/main-surface-rtt-import-v1/control-ui"
+          if [[ ! -d "$artifact_root" ]]; then
+            echo "Missing expected Control UI artifact root: $artifact_root" >&2
+            exit 1
+          fi
+          node "$RTT_SCRIPTS_DIR/import-surface-rtt.mjs" \
+            --artifact-root "$artifact_root" \
+            --surface control-ui \
+            --spec openclaw@main \
+            --version "$VERSION" \
+            --provider-mode mock-openai \
+            --require-pass
+
+      - name: Validate imported Surface RTT
+        id: validate_imports
+        if: always() && needs.measure.outputs.artifact_id != '' && steps.download_import.outcome == 'success' && steps.refresh_tracker.outcome == 'success'
+        continue-on-error: true
+        shell: bash
+        run: |
+          set -euo pipefail
+          node "$RTT_SCRIPTS_DIR/update-readme.mjs" --latest-main-only
+          node "$RTT_SCRIPTS_DIR/validate.mjs"
+          node "$RTT_SCRIPTS_DIR/surface-rtt-summary.mjs"
+
       - name: Commit imported Surface RTT
-        if: always() && github.event_name != 'pull_request' && (steps.import_rpc_surface_rtt.outcome == 'success' || steps.import_control_ui_surface_rtt.outcome == 'success')
-        working-directory: openclaw-rtt
+        if: always() && needs.measure.outputs.artifact_id != '' && steps.download_import.outcome == 'success' && steps.refresh_tracker.outcome == 'success' && steps.validate_imports.outcome == 'success'
         shell: bash
         run: |
           set -euo pipefail
@@ -305,12 +452,40 @@ jobs:
             git push
           }
 
-      - name: Fail on Surface RTT errors
-        if: always() && (steps.rpc_surface_rtt.outcome == 'failure' || steps.surface_rtt.outcome == 'failure' || steps.import_rpc_surface_rtt.outcome == 'failure' || steps.import_control_ui_surface_rtt.outcome == 'failure')
+      - name: Fail after partial Surface RTT import
+        if: always()
+        env:
+          ARTIFACT_ID: ${{ needs.measure.outputs.artifact_id }}
+          CONTROL_UI_IMPORT_RESULT: ${{ steps.import_control_ui_surface_rtt.outcome }}
+          DOWNLOAD_RESULT: ${{ steps.download_import.outcome }}
+          MEASURE_RESULT: ${{ needs.measure.result }}
+          REFRESH_RESULT: ${{ steps.refresh_tracker.outcome }}
+          RPC_IMPORT_RESULT: ${{ steps.import_rpc_surface_rtt.outcome }}
+          VALIDATE_RESULT: ${{ steps.validate_imports.outcome }}
         shell: bash
         run: |
-          echo "RPC samples: ${{ steps.rpc_surface_rtt.outcome }}"
-          echo "Control UI samples: ${{ steps.surface_rtt.outcome }}"
-          echo "RPC import: ${{ steps.import_rpc_surface_rtt.outcome }}"
-          echo "Control UI import: ${{ steps.import_control_ui_surface_rtt.outcome }}"
-          exit 1
+          set -euo pipefail
+          failed=false
+          if [[ "$MEASURE_RESULT" != "success" ]]; then
+            echo "Surface RTT measurement result: ${MEASURE_RESULT}"
+            failed=true
+          fi
+          if [[ -z "$ARTIFACT_ID" ]]; then
+            echo "No exact surface RTT import artifact was produced."
+            failed=true
+          else
+            for result in "$DOWNLOAD_RESULT" "$REFRESH_RESULT" "$RPC_IMPORT_RESULT" "$CONTROL_UI_IMPORT_RESULT" "$VALIDATE_RESULT"; do
+              if [[ "$result" != "success" ]]; then
+                failed=true
+              fi
+            done
+            echo "Surface RTT artifact id: ${ARTIFACT_ID}"
+            echo "Download: ${DOWNLOAD_RESULT}"
+            echo "Refresh: ${REFRESH_RESULT}"
+            echo "RPC import: ${RPC_IMPORT_RESULT}"
+            echo "Control UI import: ${CONTROL_UI_IMPORT_RESULT}"
+            echo "Validation: ${VALIDATE_RESULT}"
+          fi
+          if [[ "$failed" == "true" ]]; then
+            exit 1
+          fi

--- a/.github/workflows/release-surface-rtt.yml
+++ b/.github/workflows/release-surface-rtt.yml
@@ -157,6 +157,13 @@ jobs:
             exit 1
           fi
 
+      - name: Build OpenClaw CI artifacts
+        working-directory: openclaw
+        shell: bash
+        run: |
+          set -euo pipefail
+          pnpm build:ci-artifacts
+
       - name: Run ${{ matrix.package.label }} RTT samples
         id: surface_rtt
         working-directory: openclaw

--- a/scripts/channel-workflow-concurrency.test.mjs
+++ b/scripts/channel-workflow-concurrency.test.mjs
@@ -53,6 +53,7 @@ for (const { filename, measureGroup } of channelWorkflows) {
 
 const reportWorkflows = [
   "main-channel-rtt.yml",
+  "main-surface-rtt.yml",
   "release-channel-rtt.yml",
   "release-surface-rtt.yml",
   "stable-release-discord-rtt.yml",

--- a/scripts/ci-workflow-invariants.test.mjs
+++ b/scripts/ci-workflow-invariants.test.mjs
@@ -20,6 +20,15 @@ function jobBlock(workflow, jobName) {
   return remainder.slice(0, nextJob === -1 ? undefined : nextJob);
 }
 
+function stepBlock(job, stepName) {
+  const marker = `      - name: ${stepName}\n`;
+  const start = job.indexOf(marker);
+  assert.notEqual(start, -1, `missing ${stepName} step`);
+  const remainder = job.slice(start + marker.length);
+  const nextStep = remainder.indexOf("\n      - name:");
+  return remainder.slice(0, nextStep === -1 ? undefined : nextStep);
+}
+
 test("CI owns README validation without a hydration workflow", async () => {
   await assert.rejects(
     fs.access(path.join(WORKFLOWS_ROOT, "readme-hydration.yml")),
@@ -46,6 +55,7 @@ test("CI owns README validation without a hydration workflow", async () => {
 
 const SPLIT_WRITER_WORKFLOWS = [
   "main-channel-rtt.yml",
+  "main-surface-rtt.yml",
   "stable-release-discord-rtt.yml",
   "release-channel-rtt.yml",
   "release-surface-rtt.yml",
@@ -68,6 +78,89 @@ for (const filename of SPLIT_WRITER_WORKFLOWS) {
     assert.match(report, /^    permissions:\n      actions: read\n      contents: write$/mu);
   });
 }
+
+test("Main Surface preserves partial evidence across its read-only measurement boundary", async () => {
+  const workflow = await readWorkflow("main-surface-rtt.yml");
+  const measure = jobBlock(workflow, "measure");
+  const report = jobBlock(workflow, "report");
+  const prepare = stepBlock(measure, "Prepare main surface import artifact");
+  const upload = stepBlock(measure, "Upload main surface import artifact");
+  const localValidation = stepBlock(measure, "Validate Surface RTT imports");
+  const download = stepBlock(report, "Download main surface import artifact");
+  const importRpc = stepBlock(report, "Import main RPC Surface RTT");
+  const importControlUi = stepBlock(report, "Import main Control UI Surface RTT");
+  const validate = stepBlock(report, "Validate imported Surface RTT");
+  const commit = stepBlock(report, "Commit imported Surface RTT");
+  const terminal = stepBlock(report, "Fail after partial Surface RTT import");
+
+  assert.doesNotMatch(measure, /\bgit push\b/u);
+  assert.match(localValidation, /node "\$RTT_SCRIPTS_DIR\/update-readme\.mjs" --latest-main-only/u);
+  assert.match(localValidation, /node "\$RTT_SCRIPTS_DIR\/validate\.mjs"/u);
+  assert.match(
+    measure,
+    /^    outputs:\n      artifact_id: \$\{\{ steps\.upload_import\.outputs\.artifact-id \}\}\n      version: \$\{\{ steps\.openclaw_ref\.outputs\.version \}\}$/mu,
+  );
+  assert.match(report, /^    needs: measure$/mu);
+  assert.match(report, /^    if: always\(\) && github\.event_name != 'pull_request'$/mu);
+  assert.match(
+    prepare,
+    /if: always\(\) && \(steps\.rpc_surface_rtt\.outcome == 'success' \|\| steps\.surface_rtt\.outcome == 'success'\)/u,
+  );
+  assert.doesNotMatch(prepare, /manifest|metadata/u);
+  assert.match(prepare, /cp -R "\$\{\{ steps\.rpc_surface_rtt\.outputs\.output_root \}\}" "\$BUNDLE_DIR\/rpc"/u);
+  assert.match(
+    prepare,
+    /cp -R "\$\{\{ steps\.surface_rtt\.outputs\.output_root \}\}" "\$BUNDLE_DIR\/control-ui"/u,
+  );
+  assert.match(upload, /^        id: upload_import$/mu);
+  assert.match(upload, /name: main-surface-rtt-import-v1-\$\{\{ github\.run_id \}\}-\$\{\{ github\.run_attempt \}\}/u);
+  assert.doesNotMatch(upload, /overwrite:/u);
+  assert.match(upload, /if-no-files-found: error/u);
+  assert.match(download, /if: needs\.measure\.outputs\.artifact_id != ''/u);
+  assert.match(download, /artifact-ids: \$\{\{ needs\.measure\.outputs\.artifact_id \}\}/u);
+  assert.doesNotMatch(download, /^\s+name:/mu);
+  assert.match(download, /merge-multiple: true/u);
+  for (const [step, surface, root, label] of [
+    [importRpc, "rpc", "rpc", "RPC"],
+    [importControlUi, "control-ui", "control-ui", "Control UI"],
+  ]) {
+    assert.match(step, /continue-on-error: true/u);
+    assert.match(step, new RegExp(`--artifact-root "\\$artifact_root"[\\s\\S]*--surface ${surface}`, "u"));
+    assert.match(step, new RegExp(`main-surface-rtt-import-v1/${root}`, "u"));
+    assert.match(
+      step,
+      new RegExp(
+        `if \\[\\[ ! -d "\\$artifact_root" \\]\\]; then[\\s\\S]*echo "Missing expected ${label} artifact root: \\$artifact_root" >&2[\\s\\S]*exit 1`,
+        "u",
+      ),
+    );
+    assert.match(step, /--version "\$VERSION"/u);
+  }
+  assert.match(importRpc, /--provider-mode gateway-rpc[\s\S]*--scenario rpc-gateway-smoke[\s\S]*--require-pass/u);
+  assert.match(importControlUi, /--provider-mode mock-openai[\s\S]*--require-pass/u);
+  assert.match(validate, /if: always\(\)/u);
+  assert.match(validate, /continue-on-error: true/u);
+  assert.match(validate, /node "\$RTT_SCRIPTS_DIR\/update-readme\.mjs" --latest-main-only/u);
+  assert.match(validate, /node "\$RTT_SCRIPTS_DIR\/validate\.mjs"/u);
+  assert.match(commit, /steps\.validate_imports\.outcome == 'success'/u);
+  assert.doesNotMatch(commit, /import_(?:rpc|control_ui)_surface_rtt\.outcome == 'success'/u);
+  assert.ok(
+    report.indexOf("      - name: Import main RPC Surface RTT\n") <
+      report.indexOf("      - name: Import main Control UI Surface RTT\n") &&
+      report.indexOf("      - name: Import main Control UI Surface RTT\n") <
+        report.indexOf("      - name: Validate imported Surface RTT\n") &&
+      report.indexOf("      - name: Validate imported Surface RTT\n") <
+        report.indexOf("      - name: Commit imported Surface RTT\n") &&
+    report.indexOf("      - name: Commit imported Surface RTT\n") <
+      report.indexOf("      - name: Fail after partial Surface RTT import\n"),
+    "RPC evidence must validate and commit before a Control UI import failure becomes terminal",
+  );
+  assert.match(terminal, /if: always\(\)/u);
+  assert.match(terminal, /CONTROL_UI_IMPORT_RESULT: \$\{\{ steps\.import_control_ui_surface_rtt\.outcome \}\}/u);
+  assert.match(terminal, /if \[\[ "\$MEASURE_RESULT" != "success" \]\]/u);
+  assert.match(workflow, /pull_request:[\s\S]*- "scripts\/import-surface-rtt\.mjs"/u);
+  assert.doesNotMatch(workflow, /import-surface-bundle/u);
+});
 
 test("Release Channel keeps coverage serial while avoiding the main-channel schedule", async () => {
   const workflow = await readWorkflow("release-channel-rtt.yml");

--- a/scripts/data-import-readme-workflow.test.mjs
+++ b/scripts/data-import-readme-workflow.test.mjs
@@ -43,7 +43,7 @@ const IMPORT_PATHS = [
   {
     name: "main surface",
     workflow: ".github/workflows/main-surface-rtt.yml",
-    importStep: "Update Surface Dashboard",
+    importStep: "Validate imported Surface RTT",
     commitStep: "Commit imported Surface RTT",
     mode: "main",
     stage: "git add data/surfaces runs/surfaces README.md",

--- a/scripts/import-surface-rtt.mjs
+++ b/scripts/import-surface-rtt.mjs
@@ -11,6 +11,7 @@ import { resolveSurfaceRttSurface, surfaceRttRunsDir } from "./surface-rtt-confi
 function usage() {
   return [
     "Usage: node scripts/import-surface-rtt.mjs <sample-paths.tsv>",
+    "   or: node scripts/import-surface-rtt.mjs --artifact-root <dir>",
     "  --surface <rpc|control-ui>",
     "  --spec <openclaw@spec>",
     "  --version <version-or-ref>",
@@ -32,6 +33,10 @@ function parseArgs(argv) {
     }
     if (arg === "--surface") {
       args.surfaceId = argv[(index += 1)];
+      continue;
+    }
+    if (arg === "--artifact-root") {
+      args.artifactRoot = argv[(index += 1)];
       continue;
     }
     if (arg === "--spec") {
@@ -56,7 +61,15 @@ function parseArgs(argv) {
     }
     throw new Error(`Unknown argument: ${arg}\n${usage()}`);
   }
-  if (!args.samplesPath || !args.surfaceId || !args.spec || !args.version) {
+  if (args.samplesPath && args.artifactRoot) {
+    throw new Error("--artifact-root is mutually exclusive with sample-paths TSV input.");
+  }
+  if (
+    (!args.samplesPath && !args.artifactRoot) ||
+    !args.surfaceId ||
+    !args.spec ||
+    !args.version
+  ) {
     throw new Error(usage());
   }
   return args;
@@ -137,6 +150,52 @@ async function readSampleEntries(samplesPath) {
       }
       return { summaryPath, resourceMetricsPath, performanceEventsPath };
     });
+}
+
+async function requireArtifactFile(sampleDir, filename) {
+  const pathname = path.join(sampleDir, filename);
+  let stat;
+  try {
+    stat = await fs.stat(pathname);
+  } catch (error) {
+    if (error?.code === "ENOENT") {
+      throw new Error(`Missing ${filename} under ${sampleDir}.`);
+    }
+    throw error;
+  }
+  if (!stat.isFile()) {
+    throw new Error(`Expected ${filename} to be a file under ${sampleDir}.`);
+  }
+  return pathname;
+}
+
+async function readArtifactEntries(artifactRoot, surfaceId) {
+  const entries = await fs.readdir(artifactRoot, { withFileTypes: true });
+  const sampleDirs = entries
+    .filter((entry) => entry.isDirectory() && entry.name.startsWith("sample-"))
+    .map((entry) => entry.name)
+    .sort((left, right) => left.localeCompare(right, "en", { numeric: true }));
+  if (sampleDirs.length === 0) {
+    throw new Error(`No surface RTT samples found under ${artifactRoot}.`);
+  }
+
+  const samples = [];
+  for (const sampleName of sampleDirs) {
+    const sampleDir = path.join(artifactRoot, sampleName);
+    samples.push({
+      summaryPath: await requireArtifactFile(sampleDir, "qa-suite-summary.json"),
+      resourceMetricsPath: await requireArtifactFile(sampleDir, "resource-metrics.env"),
+      ...(surfaceId === "control-ui"
+        ? {
+            performanceEventsPath: await requireArtifactFile(
+              sampleDir,
+              "control-ui-events.json",
+            ),
+          }
+        : {}),
+    });
+  }
+  return samples;
 }
 
 function readAttemptCount(value) {
@@ -382,7 +441,9 @@ async function main() {
   const args = parseArgs(process.argv.slice(2));
   const surface = resolveSurfaceRttSurface(args.surfaceId);
   const scenarioId = args.scenario ?? surface.defaultScenario;
-  const entries = await readSampleEntries(path.resolve(args.samplesPath));
+  const entries = args.artifactRoot
+    ? await readArtifactEntries(path.resolve(args.artifactRoot), surface.id)
+    : await readSampleEntries(path.resolve(args.samplesPath));
   if (entries.length === 0) {
     throw new Error("No surface RTT samples to import.");
   }

--- a/scripts/pinned-workflow-scripts.test.mjs
+++ b/scripts/pinned-workflow-scripts.test.mjs
@@ -43,7 +43,6 @@ const WRITER_PATHS = [
     name: "main surface",
     workflow: ".github/workflows/main-surface-rtt.yml",
     writerStep: "Refresh RTT tracker",
-    checkoutPath: "openclaw-rtt",
   },
   {
     name: "release Telegram RSS backfill",
@@ -192,6 +191,11 @@ test("all eight workflows snapshot scripts before nine writer pulls", async (t) 
     });
   }
 
+  for (const contents of workflowCache.values()) {
+    for (const match of contents.matchAll(/"\$RTT_SCRIPTS_DIR\/([^"]+\.mjs)"/gu)) {
+      pinnedEntrypoints.add(match[1]);
+    }
+  }
   assert.deepEqual([...pinnedEntrypoints].sort(), EXPECTED_ENTRYPOINTS);
 });
 

--- a/scripts/release-report-workflow.test.mjs
+++ b/scripts/release-report-workflow.test.mjs
@@ -25,6 +25,13 @@ const WORKFLOWS = [
   },
 ];
 
+function extractStep(workflow, stepName) {
+  const marker = `      - name: ${stepName}\n`;
+  const step = workflow.split(marker)[1]?.split("\n      - name: ")[0];
+  assert.ok(step, `expected workflow step: ${stepName}`);
+  return step;
+}
+
 test("missing release imports fail only after a successful matrix", async () => {
   for (const result of ["failure", "cancelled"]) {
     const { stdout, stderr } = await execFileAsync(process.execPath, [
@@ -112,4 +119,27 @@ test("release surface workflow measures native RPC and Control UI", async () => 
     workflow,
     /if \[\[ "\$surface" == "control-ui" \]\]; then[\s\S]*import_args\+=\(--require-pass\)/u,
   );
+});
+
+test("surface workflows build runtime and Control UI artifacts before sampling", async () => {
+  for (const { workflowPath, measurementStep } of [
+    {
+      workflowPath: ".github/workflows/main-surface-rtt.yml",
+      measurementStep: "Run RPC RTT samples",
+    },
+    {
+      workflowPath: ".github/workflows/release-surface-rtt.yml",
+      measurementStep: "Run ${{ matrix.package.label }} RTT samples",
+    },
+  ]) {
+    const workflow = await fs.readFile(path.join(REPO_ROOT, workflowPath), "utf8");
+    const buildStep = extractStep(workflow, "Build OpenClaw CI artifacts");
+    assert.match(buildStep, /working-directory: openclaw/u);
+    assert.match(buildStep, /pnpm build:ci-artifacts/u);
+    assert.ok(
+      workflow.indexOf("      - name: Build OpenClaw CI artifacts\n") <
+        workflow.indexOf(`      - name: ${measurementStep}\n`),
+      `${workflowPath}: build must finish before measurement`,
+    );
+  }
 });

--- a/scripts/surface-rtt.test.mjs
+++ b/scripts/surface-rtt.test.mjs
@@ -28,6 +28,32 @@ async function readJsonl(pathname) {
     .map((line) => JSON.parse(line));
 }
 
+async function writeRpcArtifactSample(artifactRoot, name, second, rttMs) {
+  const sampleDir = path.join(artifactRoot, name);
+  await writeJson(path.join(sampleDir, "qa-suite-summary.json"), {
+    counts: { total: 1, passed: 1, failed: 0 },
+    run: {
+      startedAt: `2026-05-16T00:00:${String(second).padStart(2, "0")}.000Z`,
+      finishedAt: `2026-05-16T00:00:${String(second + 1).padStart(2, "0")}.000Z`,
+      providerMode: "gateway-rpc",
+    },
+    scenarios: [
+      {
+        id: "rpc-gateway-smoke",
+        status: "pass",
+        rttMeasurement: {
+          finalMatchedReplyRttMs: rttMs,
+          source: "gateway-rpc",
+        },
+      },
+    ],
+  });
+  await fs.writeFile(
+    path.join(sampleDir, "resource-metrics.env"),
+    `max_rss_kb=${100000 + rttMs}\nelapsed_seconds=1\nattempts=1\n`,
+  );
+}
+
 test("imports Control UI surface RTT from performance events", async () => {
   const workspace = await makeWorkspace();
   const summaryPath = path.join(workspace, "sample-1", "qa-suite-summary.json");
@@ -196,4 +222,96 @@ test("imports explicit native Gateway RPC failure evidence", async () => {
     await fs.readFile(path.join(workspace, row.artifacts.resultPath), "utf8"),
   );
   assert.deepEqual(result, row);
+});
+
+test("imports numerically sorted RPC sample directories from an artifact root", async () => {
+  const workspace = await makeWorkspace();
+  const artifactRoot = path.join(workspace, "artifacts");
+  await writeRpcArtifactSample(artifactRoot, "sample-10", 10, 110);
+  await writeRpcArtifactSample(artifactRoot, "sample-2", 2, 22);
+
+  await execFileAsync(
+    process.execPath,
+    [
+      IMPORT_SCRIPT,
+      "--artifact-root",
+      artifactRoot,
+      "--surface",
+      "rpc",
+      "--spec",
+      "openclaw@main",
+      "--version",
+      "2026.5.16+artifact",
+      "--provider-mode",
+      "gateway-rpc",
+      "--scenario",
+      "rpc-gateway-smoke",
+      "--require-pass",
+    ],
+    { cwd: workspace },
+  );
+
+  const [row] = await readJsonl(
+    path.join(workspace, "data/surfaces/rpc/2026.5.16+artifact.jsonl"),
+  );
+  assert.deepEqual(
+    row.samples.map((sample) => sample.rttMs),
+    [22, 110],
+  );
+  assert.equal(row.run.startedAt, "2026-05-16T00:00:02.000Z");
+  assert.equal(row.run.finishedAt, "2026-05-16T00:00:11.000Z");
+});
+
+test("artifact roots require complete surface-specific evidence", async () => {
+  const workspace = await makeWorkspace();
+  const artifactRoot = path.join(workspace, "artifacts");
+  const sampleDir = path.join(artifactRoot, "sample-1");
+  await fs.mkdir(artifactRoot, { recursive: true });
+  const args = [
+    IMPORT_SCRIPT,
+    "--artifact-root",
+    artifactRoot,
+    "--surface",
+    "control-ui",
+    "--spec",
+    "openclaw@main",
+    "--version",
+    "2026.5.16+artifact",
+  ];
+
+  await assert.rejects(execFileAsync(process.execPath, args, { cwd: workspace }), /No surface RTT samples/u);
+  await fs.mkdir(sampleDir);
+  await assert.rejects(execFileAsync(process.execPath, args, { cwd: workspace }), /qa-suite-summary\.json/u);
+  await writeJson(path.join(sampleDir, "qa-suite-summary.json"), {});
+  await assert.rejects(execFileAsync(process.execPath, args, { cwd: workspace }), /resource-metrics\.env/u);
+  await fs.writeFile(path.join(sampleDir, "resource-metrics.env"), "attempts=1\n");
+  await assert.rejects(execFileAsync(process.execPath, args, { cwd: workspace }), /control-ui-events\.json/u);
+});
+
+test("artifact-root input is mutually exclusive with sample-paths TSV input", async () => {
+  const workspace = await makeWorkspace();
+  const samplesPath = path.join(workspace, "samples.tsv");
+  const artifactRoot = path.join(workspace, "artifacts");
+  await fs.writeFile(samplesPath, "");
+  await fs.mkdir(artifactRoot);
+
+  await assert.rejects(
+    execFileAsync(
+      process.execPath,
+      [
+        IMPORT_SCRIPT,
+        samplesPath,
+        "--artifact-root",
+        artifactRoot,
+        "--surface",
+        "rpc",
+        "--spec",
+        "openclaw@main",
+        "--version",
+        "2026.5.16+artifact",
+      ],
+      { cwd: workspace },
+    ),
+    /mutually exclusive/u,
+  );
 });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the Main Surface RTT workflow granted repository write access to the measurement job and made the first RTT sample pay for lazy gateway and Control UI compilation. That mixed measurement with publication ownership and could distort the recorded baseline.

## Why This Change Was Made

The workflow now separates a read-only measurement job from the serialized writer report. Measurement explicitly prebuilds OpenClaw, uploads completed RPC and Control UI evidence under an immutable run-attempt artifact, and exposes the exact artifact ID and measured version to the report.

The report downloads only that exact artifact, imports RPC and Control UI independently through the canonical `import-surface-rtt.mjs --artifact-root` path, validates and commits successful partial evidence, then preserves terminal measurement or import failures. Release Surface RTT also performs the same explicit prebuild before sampling without otherwise changing its publication flow.

## User Impact

No user-visible runtime behavior changes. Maintainers get cleaner RTT samples, read-only measurement credentials, deterministic report ownership, fail-closed artifact handling, and preserved partial evidence.

## Evidence

- `node --test scripts/*.test.mjs`: 195/195 passing.
- `actionlint`, `node --check scripts/*.mjs`, all RTT validators, README regeneration, and diff checks pass.
- Exact-head independent review approved `32c0da847b4dcef815e55246b5fffd9a97e9eb58`.
- Production/tooling: +291/-45, net +246. Tests: +248/-2, net +246.
- Verified the supported release-floor build profile: OpenClaw `package.json` and `scripts/build-all.mts` confirm `pnpm build:ci-artifacts` covers gateway runtime and Control UI artifacts used by these workflows.
- Hosted Main Surface run https://github.com/openclaw/openclaw-rtt/actions/runs/33859693735 succeeded at exact head `32c0da847b4dcef815e55246b5fffd9a97e9eb58`: job 4m18s; install 12s; explicit prebuild 2m02s; three RPC samples 20s total; three Control UI samples 12s total; report correctly skipped on the pull request.

<!-- agent-transcript:start -->
## Agent Transcript

<details>
<summary>Redacted codex session transcript</summary>

````text
source: [LOCAL_SESSION]
redaction: broad local paths, account details, raw tool output, environment data, and unrelated turns removed

[user]
Sole executor for the openclaw-rtt surface ownership repair. Start from exact origin/main, verify no overlap with PR #66, use a fresh worktree, and personally verify that `pnpm build:ci-artifacts` covers gateway runtime and Control UI.

Main Surface must use read-only measurement permissions, prebuild before samples, preserve partial RPC evidence when Control UI fails, and move repository publication to a serialized report job. Release Surface should only gain the explicit prebuild. Extend existing workflow/import tests, validate README stability, sign the commit, and push the branch without opening a PR.

[assistant]
Base is frozen at `cb9633d90a0f85f365908af47d0d963b7510b5b0`. PR #66 overlaps only an unrelated harness file, so there is no collision.

[assistant]
The historical record confirms the regression: Main Surface previously had an explicit build, then drifted back to lazy compilation. The intended contracts are read-only measurement, serialized writer ownership, prebuild ordering, and partial-result artifact handoff.

[assistant]
The focused regression suite and actionlint pass. Measurement remains read-only; the report owns repository writes and the shared writer queue.

[user]
Correct the artifact handoff at exact head `166f8b1a`. Delete the standalone bundle helper, restore Release Surface metadata/import behavior to base plus prebuild, and extend canonical `import-surface-rtt.mjs` with mutually exclusive `--artifact-root`.

Main Surface must upload an immutable run-id plus run-attempt artifact, expose the exact artifact ID and measured version, download by artifact ID, import RPC and Control UI independently with report-owned arguments, commit validated partial evidence, and fail terminally for measurement/import errors.

[assistant]
The reviewed correction belongs in the canonical importer: artifact layout is resolved by `import-surface-rtt.mjs`; release metadata policy remains in its workflow.

[assistant]
The importer now supports numeric `sample-*` ordering and surface-specific evidence requirements. Release Surface is back to its base contract plus the explicit build.

[assistant]
Main now uses the upload action's exact `artifact-id`, never a name lookup. The report imports fixed RPC and Control UI roots independently and validates/commits successful partial evidence before the terminal status step.

[assistant]
Full tests are `195/195`; actionlint, syntax checks, validators, README regeneration, and diff checks pass. Production/tooling net is `+246`, down from the previous `+367`.

[user]
Exact-head review found one blocking P1: both report import steps treated a missing expected artifact root as success. Make missing RPC or Control UI roots write a clear stderr error and exit nonzero. Keep partial evidence publication through continue-on-error and the terminal status step.

[assistant]
Both expected roots now fail closed with stderr and `exit 1`. The existing invariant requires that behavior while preserving import, validation, commit, then terminal-failure ordering.

[assistant]
Full validation is clean again: `195/195`, actionlint, syntax, validators, README byte identity, and diff checks. Signed head is `32c0da847b4dcef815e55246b5fffd9a97e9eb58`.

[user]
Exact-head review approved `32c0da84`. Open a draft PR against main, include a redacted agent transcript, and note that the hosted Main Surface PR run is still required.
````

</details>
<!-- agent-transcript:end -->
