### PR TITLE
improve(ci): cache release channel builds

### DIFF
--- a/.github/workflows/release-channel-rtt.yml
+++ b/.github/workflows/release-channel-rtt.yml
@@ -25,6 +25,11 @@ on:
         required: false
         default: "20"
         type: string
+      publish_results:
+        description: Import successful measurements into the RTT tracker
+        required: false
+        default: true
+        type: boolean
 
 permissions:
   actions: read
@@ -216,6 +221,43 @@ jobs:
             exit 1
           fi
 
+      - name: Resolve OpenClaw build cache identity
+        id: build_cache
+        env:
+          CACHE_ARCH: ${{ runner.arch }}
+          CACHE_OS: ${{ runner.os }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          node_version="$(node --version)"
+          pnpm_version="$(pnpm --version)"
+          release_head="$(git -C openclaw rev-parse HEAD)"
+          qa_head="$(git -C openclaw-qa rev-parse HEAD)"
+          qa_patch_digest="$(
+            {
+              git -C openclaw-qa diff --binary --no-ext-diff HEAD --
+              while IFS= read -r -d '' file; do
+                printf 'untracked:%s\0' "$file"
+                git -C openclaw-qa hash-object -- "$file"
+              done < <(git -C openclaw-qa ls-files --others --exclude-standard -z | sort -z)
+            } | sha256sum | cut -d' ' -f1
+          )"
+          identity="openclaw-release-channel-rtt-build-v1-${CACHE_OS}-${CACHE_ARCH}-node-${node_version}-pnpm-${pnpm_version}-full-private-qa"
+          # Channel links live under ignored node_modules; both builds compile the
+          # complete checked-out source tree. Exact source and patch identities
+          # therefore permit cross-channel reuse without restoring channel output.
+          {
+            printf 'release_key=%s-release-%s\n' "$identity" "$release_head"
+            printf 'qa_key=%s-qa-%s-patch-%s\n' "$identity" "$qa_head" "$qa_patch_digest"
+          } >>"$GITHUB_OUTPUT"
+
+      - name: Restore OpenClaw release build cache
+        id: restore_release_build_cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: openclaw/.artifacts/build-all-cache
+          key: ${{ steps.build_cache.outputs.release_key }}
+
       - name: Build OpenClaw release
         working-directory: openclaw
         env:
@@ -227,6 +269,20 @@ jobs:
           set -euo pipefail
           time pnpm build
 
+      - name: Save OpenClaw release build cache
+        if: steps.restore_release_build_cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: openclaw/.artifacts/build-all-cache
+          key: ${{ steps.restore_release_build_cache.outputs.cache-primary-key }}
+
+      - name: Restore OpenClaw QA harness build cache
+        id: restore_qa_build_cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: openclaw-qa/.artifacts/build-all-cache
+          key: ${{ steps.build_cache.outputs.qa_key }}
+
       - name: Build OpenClaw QA harness
         working-directory: openclaw-qa
         env:
@@ -237,6 +293,13 @@ jobs:
         run: |
           set -euo pipefail
           time pnpm build
+
+      - name: Save OpenClaw QA harness build cache
+        if: steps.restore_qa_build_cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: openclaw-qa/.artifacts/build-all-cache
+          key: ${{ steps.restore_qa_build_cache.outputs.cache-primary-key }}
 
       - name: Run ${{ matrix.package.label }} RTT samples
         id: channel_rtt
@@ -418,7 +481,7 @@ jobs:
     needs:
       - resolve
       - measure
-    if: always() && needs.resolve.outputs.should_run == 'true'
+    if: always() && needs.resolve.outputs.should_run == 'true' && (github.event_name != 'workflow_dispatch' || inputs.publish_results)
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:

--- a/.github/workflows/release-channel-rtt.yml
+++ b/.github/workflows/release-channel-rtt.yml
@@ -173,30 +173,6 @@ jobs:
           set -euo pipefail
           node scripts/patch-openclaw-release-qa-harness.mjs ../openclaw-qa
 
-      - name: Link OpenClaw release channel package
-        shell: bash
-        run: |
-          set -euo pipefail
-          channel_dir="openclaw/extensions/${{ matrix.package.channel }}"
-          if [[ ! -d "$channel_dir" ]]; then
-            echo "OpenClaw release does not contain ${channel_dir}." >&2
-            exit 1
-          fi
-          release_channel_dir="${GITHUB_WORKSPACE:?}/${channel_dir}"
-          mkdir -p openclaw/node_modules/@openclaw
-          ln -sfn "$release_channel_dir" "openclaw/node_modules/@openclaw/${{ matrix.package.channel }}"
-          mkdir -p openclaw-qa/node_modules/@openclaw
-          ln -sfn "$release_channel_dir" "openclaw-qa/node_modules/@openclaw/${{ matrix.package.channel }}"
-          for link_path in \
-            "openclaw/node_modules/@openclaw/${{ matrix.package.channel }}" \
-            "openclaw-qa/node_modules/@openclaw/${{ matrix.package.channel }}"
-          do
-            if [[ "$(realpath "$link_path")" != "$(realpath "$release_channel_dir")" ]]; then
-              echo "${link_path} does not resolve to ${release_channel_dir}." >&2
-              exit 1
-            fi
-          done
-
       - name: Verify OpenClaw release ref
         working-directory: openclaw
         shell: bash
@@ -242,10 +218,10 @@ jobs:
               done < <(git -C openclaw-qa ls-files --others --exclude-standard -z | sort -z)
             } | sha256sum | cut -d' ' -f1
           )"
-          identity="openclaw-release-channel-rtt-build-v1-${CACHE_OS}-${CACHE_ARCH}-node-${node_version}-pnpm-${pnpm_version}-full-private-qa"
-          # Channel links live under ignored node_modules; both builds compile the
-          # complete checked-out source tree. Exact source and patch identities
-          # therefore permit cross-channel reuse without restoring channel output.
+          identity="openclaw-release-channel-rtt-build-v2-${CACHE_OS}-${CACHE_ARCH}-node-${node_version}-pnpm-${pnpm_version}-full-private-qa"
+          # Channel links are created only after both builds and cache saves.
+          # Exact source and patch identities can therefore be reused across
+          # channels without capturing channel-dependent node_modules state.
           {
             printf 'release_key=%s-release-%s\n' "$identity" "$release_head"
             printf 'qa_key=%s-qa-%s-patch-%s\n' "$identity" "$qa_head" "$qa_patch_digest"
@@ -300,6 +276,30 @@ jobs:
         with:
           path: openclaw-qa/.artifacts/build-all-cache
           key: ${{ steps.restore_qa_build_cache.outputs.cache-primary-key }}
+
+      - name: Link OpenClaw release channel package
+        shell: bash
+        run: |
+          set -euo pipefail
+          channel_dir="openclaw/extensions/${{ matrix.package.channel }}"
+          if [[ ! -d "$channel_dir" ]]; then
+            echo "OpenClaw release does not contain ${channel_dir}." >&2
+            exit 1
+          fi
+          release_channel_dir="${GITHUB_WORKSPACE:?}/${channel_dir}"
+          mkdir -p openclaw/node_modules/@openclaw
+          ln -sfn "$release_channel_dir" "openclaw/node_modules/@openclaw/${{ matrix.package.channel }}"
+          mkdir -p openclaw-qa/node_modules/@openclaw
+          ln -sfn "$release_channel_dir" "openclaw-qa/node_modules/@openclaw/${{ matrix.package.channel }}"
+          for link_path in \
+            "openclaw/node_modules/@openclaw/${{ matrix.package.channel }}" \
+            "openclaw-qa/node_modules/@openclaw/${{ matrix.package.channel }}"
+          do
+            if [[ "$(realpath "$link_path")" != "$(realpath "$release_channel_dir")" ]]; then
+              echo "${link_path} does not resolve to ${release_channel_dir}." >&2
+              exit 1
+            fi
+          done
 
       - name: Run ${{ matrix.package.label }} RTT samples
         id: channel_rtt

--- a/.github/workflows/release-channel-rtt.yml
+++ b/.github/workflows/release-channel-rtt.yml
@@ -30,6 +30,11 @@ on:
         required: false
         default: true
         type: boolean
+      prepare_only:
+        description: Prepare and save build caches without sampling
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   actions: read
@@ -93,7 +98,7 @@ jobs:
     timeout-minutes: 120
     environment: qa-live-shared
     concurrency:
-      group: channel-rtt-measure-${{ matrix.package.channel }}
+      group: ${{ github.event_name == 'workflow_dispatch' && inputs.prepare_only && format('release-channel-rtt-prepare-{0}', github.run_id) || format('channel-rtt-measure-{0}', matrix.package.channel) }}
       cancel-in-progress: false
       queue: max
     strategy:
@@ -278,6 +283,7 @@ jobs:
           key: ${{ steps.restore_qa_build_cache.outputs.cache-primary-key }}
 
       - name: Link OpenClaw release channel package
+        if: github.event_name != 'workflow_dispatch' || inputs.prepare_only != true
         shell: bash
         run: |
           set -euo pipefail
@@ -303,6 +309,7 @@ jobs:
 
       - name: Run ${{ matrix.package.label }} RTT samples
         id: channel_rtt
+        if: github.event_name != 'workflow_dispatch' || inputs.prepare_only != true
         working-directory: openclaw
         env:
           INPUT_SAMPLES: ${{ github.event_name == 'workflow_dispatch' && inputs.samples || '' }}
@@ -442,6 +449,7 @@ jobs:
           done
 
       - name: Prepare ${{ matrix.package.label }} release import artifact
+        if: github.event_name != 'workflow_dispatch' || inputs.prepare_only != true
         working-directory: openclaw
         shell: bash
         run: |
@@ -460,6 +468,7 @@ jobs:
           } >"$import_dir/metadata.env"
 
       - name: Upload ${{ matrix.package.label }} release import artifact
+        if: github.event_name != 'workflow_dispatch' || inputs.prepare_only != true
         uses: actions/upload-artifact@v7.0.1
         with:
           name: release-channel-rtt-import-${{ matrix.package.channel }}-${{ matrix.package.version }}
@@ -468,7 +477,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload ${{ matrix.package.label }} RTT artifacts
-        if: always()
+        if: always() && (github.event_name != 'workflow_dispatch' || inputs.prepare_only != true)
         uses: actions/upload-artifact@v7.0.1
         with:
           name: release-channel-rtt-${{ matrix.package.channel }}-${{ matrix.package.version }}-${{ github.run_id }}-${{ github.run_attempt }}
@@ -481,7 +490,7 @@ jobs:
     needs:
       - resolve
       - measure
-    if: always() && needs.resolve.outputs.should_run == 'true' && (github.event_name != 'workflow_dispatch' || inputs.publish_results)
+    if: always() && needs.resolve.outputs.should_run == 'true' && (github.event_name != 'workflow_dispatch' || (inputs.prepare_only != true && inputs.publish_results))
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:

--- a/scripts/channel-workflow-concurrency.test.mjs
+++ b/scripts/channel-workflow-concurrency.test.mjs
@@ -30,10 +30,6 @@ const channelWorkflows = [
     filename: "main-channel-rtt.yml",
     measureGroup: "channel-rtt-measure-${{ matrix.channel }}",
   },
-  {
-    filename: "release-channel-rtt.yml",
-    measureGroup: "channel-rtt-measure-${{ matrix.package.channel }}",
-  },
 ];
 
 for (const { filename, measureGroup } of channelWorkflows) {
@@ -50,6 +46,25 @@ for (const { filename, measureGroup } of channelWorkflows) {
     assertLine(strategy, "      max-parallel: 1");
   });
 }
+
+test("release-channel-rtt.yml isolates prepare-only runs without changing normal channel queues", async () => {
+  const workflow = await fs.readFile(new URL("release-channel-rtt.yml", workflowsDir), "utf8");
+  const measure = extractJob(workflow, "measure");
+  const concurrency = extractBlock(measure, "concurrency");
+  const strategy = extractBlock(measure, "strategy");
+
+  assertLine(
+    concurrency,
+    "      group: ${{ github.event_name == 'workflow_dispatch' && inputs.prepare_only && format('release-channel-rtt-prepare-{0}', github.run_id) || format('channel-rtt-measure-{0}', matrix.package.channel) }}",
+  );
+  assert.match(concurrency, /format\('channel-rtt-measure-\{0\}', matrix\.package\.channel\)/u);
+  assert.match(concurrency, /format\('release-channel-rtt-prepare-\{0\}', github\.run_id\)/u);
+  assertLine(concurrency, "      cancel-in-progress: false");
+  assertLine(concurrency, "      queue: max");
+  assert.doesNotMatch(concurrency, /github\.ref/u);
+  assertLine(strategy, "      max-parallel: 1");
+  assertLine(measure, "    environment: qa-live-shared");
+});
 
 const reportWorkflows = [
   "main-channel-rtt.yml",

--- a/scripts/ci-workflow-invariants.test.mjs
+++ b/scripts/ci-workflow-invariants.test.mjs
@@ -174,6 +174,24 @@ test("Release Channel keeps coverage serial while avoiding the main-channel sche
   );
 });
 
+test("Release Channel confines live credentials to the skipped sample step", async () => {
+  const workflow = await readWorkflow("release-channel-rtt.yml");
+  const measure = jobBlock(workflow, "measure");
+  const sample = stepBlock(measure, "Run ${{ matrix.package.label }} RTT samples");
+  const workflowSecrets = workflow.match(/\$\{\{ secrets\.[A-Z0-9_]+ \}\}/gu) ?? [];
+  const sampleSecrets = sample.match(/\$\{\{ secrets\.[A-Z0-9_]+ \}\}/gu) ?? [];
+
+  assert.deepEqual(sampleSecrets, [
+    "${{ secrets.OPENCLAW_QA_CONVEX_SITE_URL }}",
+    "${{ secrets.OPENCLAW_QA_CONVEX_SECRET_CI }}",
+  ]);
+  assert.deepEqual(workflowSecrets, sampleSecrets);
+  assert.match(
+    sample,
+    /if: github\.event_name != 'workflow_dispatch' \|\| inputs\.prepare_only != true/u,
+  );
+});
+
 const RELEASE_MATRIX_JOB_NAMES = new Map([
   [
     "stable-release-discord-rtt.yml",

--- a/scripts/release-channel-build-cache-workflow.test.mjs
+++ b/scripts/release-channel-build-cache-workflow.test.mjs
@@ -18,7 +18,7 @@ function stepIndex(workflow, name) {
   return index;
 }
 
-test("benchmark dispatch can skip publication without changing schedule behavior", async () => {
+test("dispatch modes preserve safe publication defaults", async () => {
   const workflow = await fs.readFile(workflowPath, "utf8");
   assert.match(
     workflow,
@@ -26,7 +26,11 @@ test("benchmark dispatch can skip publication without changing schedule behavior
   );
   assert.match(
     workflow,
-    /if: always\(\) && needs\.resolve\.outputs\.should_run == 'true' && \(github\.event_name != 'workflow_dispatch' \|\| inputs\.publish_results\)/u,
+    /prepare_only:\n\s+description: Prepare and save build caches without sampling\n\s+required: false\n\s+default: false\n\s+type: boolean/u,
+  );
+  assert.match(
+    workflow,
+    /if: always\(\) && needs\.resolve\.outputs\.should_run == 'true' && \(github\.event_name != 'workflow_dispatch' \|\| \(inputs\.prepare_only != true && inputs\.publish_results\)\)/u,
   );
 });
 
@@ -117,4 +121,24 @@ test("native cache restore and save tightly wrap both full builds", async () => 
   assert.notEqual(linkIndex, -1);
   assert.equal(stepNames[linkIndex - 1], "Save OpenClaw QA harness build cache");
   assert.equal(stepNames[linkIndex + 1], "Run ${{ matrix.package.label }} RTT samples");
+});
+
+test("prepare-only dispatch skips sampling and all evidence publication", async () => {
+  const workflow = await fs.readFile(workflowPath, "utf8");
+  const prepareGate =
+    /if: github\.event_name != 'workflow_dispatch' \|\| inputs\.prepare_only != true/u;
+
+  for (const name of [
+    "Link OpenClaw release channel package",
+    "Run ${{ matrix.package.label }} RTT samples",
+    "Prepare ${{ matrix.package.label }} release import artifact",
+    "Upload ${{ matrix.package.label }} release import artifact",
+  ]) {
+    assert.match(extractStep(workflow, name), prepareGate);
+  }
+
+  assert.match(
+    extractStep(workflow, "Upload ${{ matrix.package.label }} RTT artifacts"),
+    /if: always\(\) && \(github\.event_name != 'workflow_dispatch' \|\| inputs\.prepare_only != true\)/u,
+  );
 });

--- a/scripts/release-channel-build-cache-workflow.test.mjs
+++ b/scripts/release-channel-build-cache-workflow.test.mjs
@@ -43,8 +43,9 @@ test("release and QA native build caches use exact source identities", async () 
   assert.match(identity, /sha256sum \| cut -d' ' -f1/u);
   assert.match(
     identity,
-    /identity="openclaw-release-channel-rtt-build-v1-\$\{CACHE_OS\}-\$\{CACHE_ARCH\}-node-\$\{node_version\}-pnpm-\$\{pnpm_version\}-full-private-qa"/u,
+    /identity="openclaw-release-channel-rtt-build-v2-\$\{CACHE_OS\}-\$\{CACHE_ARCH\}-node-\$\{node_version\}-pnpm-\$\{pnpm_version\}-full-private-qa"/u,
   );
+  assert.doesNotMatch(identity, /openclaw-release-channel-rtt-build-v1/u);
   assert.match(
     identity,
     /printf 'release_key=%s-release-%s\\n' "\$identity" "\$release_head"/u,
@@ -65,6 +66,8 @@ test("native cache restore and save tightly wrap both full builds", async () => 
     "Restore OpenClaw QA harness build cache",
     "Build OpenClaw QA harness",
     "Save OpenClaw QA harness build cache",
+    "Link OpenClaw release channel package",
+    "Run ${{ matrix.package.label }} RTT samples",
   ];
   const indices = names.map((name) => stepIndex(workflow, name));
   assert.deepEqual(indices, indices.toSorted((left, right) => left - right));
@@ -108,4 +111,10 @@ test("native cache restore and save tightly wrap both full builds", async () => 
   );
   assert.equal((workflow.match(/\btime pnpm build$/gmu) ?? []).length, 2);
   assert.doesNotMatch(workflow, /pnpm build:ci-artifacts/u);
+
+  const stepNames = [...workflow.matchAll(/^      - name: (.+)$/gmu)].map((match) => match[1]);
+  const linkIndex = stepNames.indexOf("Link OpenClaw release channel package");
+  assert.notEqual(linkIndex, -1);
+  assert.equal(stepNames[linkIndex - 1], "Save OpenClaw QA harness build cache");
+  assert.equal(stepNames[linkIndex + 1], "Run ${{ matrix.package.label }} RTT samples");
 });

--- a/scripts/release-channel-build-cache-workflow.test.mjs
+++ b/scripts/release-channel-build-cache-workflow.test.mjs
@@ -1,0 +1,111 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import test from "node:test";
+
+const workflowPath = new URL("../.github/workflows/release-channel-rtt.yml", import.meta.url);
+const cachePin = "55cc8345863c7cc4c66a329aec7e433d2d1c52a9";
+
+function extractStep(workflow, name) {
+  const marker = `      - name: ${name}\n`;
+  const step = workflow.split(marker)[1]?.split("\n      - name: ")[0];
+  assert.ok(step, `missing workflow step: ${name}`);
+  return step;
+}
+
+function stepIndex(workflow, name) {
+  const index = workflow.indexOf(`      - name: ${name}\n`);
+  assert.notEqual(index, -1, `missing workflow step: ${name}`);
+  return index;
+}
+
+test("benchmark dispatch can skip publication without changing schedule behavior", async () => {
+  const workflow = await fs.readFile(workflowPath, "utf8");
+  assert.match(
+    workflow,
+    /publish_results:\n\s+description: Import successful measurements into the RTT tracker\n\s+required: false\n\s+default: true\n\s+type: boolean/u,
+  );
+  assert.match(
+    workflow,
+    /if: always\(\) && needs\.resolve\.outputs\.should_run == 'true' && \(github\.event_name != 'workflow_dispatch' \|\| inputs\.publish_results\)/u,
+  );
+});
+
+test("release and QA native build caches use exact source identities", async () => {
+  const workflow = await fs.readFile(workflowPath, "utf8");
+  const identity = extractStep(workflow, "Resolve OpenClaw build cache identity");
+
+  assert.match(identity, /node_version="\$\(node --version\)"/u);
+  assert.match(identity, /pnpm_version="\$\(pnpm --version\)"/u);
+  assert.match(identity, /release_head="\$\(git -C openclaw rev-parse HEAD\)"/u);
+  assert.match(identity, /qa_head="\$\(git -C openclaw-qa rev-parse HEAD\)"/u);
+  assert.match(identity, /git -C openclaw-qa diff --binary --no-ext-diff HEAD --/u);
+  assert.match(identity, /git -C openclaw-qa ls-files --others --exclude-standard -z/u);
+  assert.match(identity, /sha256sum \| cut -d' ' -f1/u);
+  assert.match(
+    identity,
+    /identity="openclaw-release-channel-rtt-build-v1-\$\{CACHE_OS\}-\$\{CACHE_ARCH\}-node-\$\{node_version\}-pnpm-\$\{pnpm_version\}-full-private-qa"/u,
+  );
+  assert.match(
+    identity,
+    /printf 'release_key=%s-release-%s\\n' "\$identity" "\$release_head"/u,
+  );
+  assert.match(
+    identity,
+    /printf 'qa_key=%s-qa-%s-patch-%s\\n' "\$identity" "\$qa_head" "\$qa_patch_digest"/u,
+  );
+  assert.doesNotMatch(identity, /restore_prefix|save_suffix|GITHUB_RUN_ID|GITHUB_RUN_ATTEMPT/u);
+});
+
+test("native cache restore and save tightly wrap both full builds", async () => {
+  const workflow = await fs.readFile(workflowPath, "utf8");
+  const names = [
+    "Restore OpenClaw release build cache",
+    "Build OpenClaw release",
+    "Save OpenClaw release build cache",
+    "Restore OpenClaw QA harness build cache",
+    "Build OpenClaw QA harness",
+    "Save OpenClaw QA harness build cache",
+  ];
+  const indices = names.map((name) => stepIndex(workflow, name));
+  assert.deepEqual(indices, indices.toSorted((left, right) => left - right));
+
+  const releaseRestore = extractStep(workflow, names[0]);
+  const releaseSave = extractStep(workflow, names[2]);
+  const qaRestore = extractStep(workflow, names[3]);
+  const qaSave = extractStep(workflow, names[5]);
+
+  for (const step of [releaseRestore, qaRestore]) {
+    assert.match(step, new RegExp(`uses: actions/cache/restore@${cachePin} # v6\\.1\\.0`, "u"));
+  }
+  for (const step of [releaseSave, qaSave]) {
+    assert.match(step, new RegExp(`uses: actions/cache/save@${cachePin} # v6\\.1\\.0`, "u"));
+  }
+  assert.match(releaseRestore, /path: openclaw\/\.artifacts\/build-all-cache/u);
+  assert.match(releaseSave, /path: openclaw\/\.artifacts\/build-all-cache/u);
+  assert.match(qaRestore, /path: openclaw-qa\/\.artifacts\/build-all-cache/u);
+  assert.match(qaSave, /path: openclaw-qa\/\.artifacts\/build-all-cache/u);
+  assert.match(releaseRestore, /id: restore_release_build_cache/u);
+  assert.match(releaseRestore, /key: \$\{\{ steps\.build_cache\.outputs\.release_key \}\}/u);
+  assert.doesNotMatch(releaseRestore, /restore-keys:/u);
+  assert.match(qaRestore, /id: restore_qa_build_cache/u);
+  assert.match(qaRestore, /key: \$\{\{ steps\.build_cache\.outputs\.qa_key \}\}/u);
+  assert.doesNotMatch(qaRestore, /restore-keys:/u);
+  assert.match(
+    releaseSave,
+    /if: steps\.restore_release_build_cache\.outputs\.cache-hit != 'true'/u,
+  );
+  assert.match(
+    releaseSave,
+    /key: \$\{\{ steps\.restore_release_build_cache\.outputs\.cache-primary-key \}\}/u,
+  );
+  assert.match(
+    qaSave,
+    /if: steps\.restore_qa_build_cache\.outputs\.cache-hit != 'true'/u,
+  );
+  assert.match(
+    qaSave,
+    /key: \$\{\{ steps\.restore_qa_build_cache\.outputs\.cache-primary-key \}\}/u,
+  );
+  assert.equal((workflow.match(/\btime pnpm build$/gmu) ?? []).length, 2);
+  assert.doesNotMatch(workflow, /pnpm build:ci-artifacts/u);
+});


### PR DESCRIPTION
## What Problem This Solves

Release Channel RTT matrix jobs rebuilt both the historical OpenClaw release and the current QA harness from scratch for every channel/version entry, even though both builds already maintain validated native build caches. A cold job spent 4m59s building the release and 4m34s building the QA harness, or 9m33s before sampling, and the workflow did not persist those caches for later exact-source jobs.

Exact-head review then found a cache-safety blocker: the channel package was linked into ignored `node_modules` before both builds. That link could affect build output without participating in the cache identity, allowing an immutable v1 entry to contain channel-dependent output under a channel-independent key.

## Why This Change Was Made

The workflow now restores and saves only each checkout's native `.artifacts/build-all-cache` around the existing full `pnpm build` commands.

Cache identity is exact and stable:

- release: runner OS, architecture, actual Node version, actual pnpm version, the full private-QA build profile, and release HEAD
- QA harness: the same runtime/build identity plus immutable QA HEAD and a digest of all compatibility-patched tracked and added files

There are no restore prefixes or cross-revision fallbacks. Cache saves run only after a primary-key miss and use the restore action's `cache-primary-key`, so concurrent cold jobs race safely on one immutable entry instead of uploading duplicate warm caches.

Both full builds and both cache saves now complete before the channel package link is created. The link step runs immediately before RTT sampling, so cached build output cannot capture channel-dependent `node_modules` state. The cache namespace is bumped from `openclaw-release-channel-rtt-build-v1` to `...-v2`; immutable v1 entries cannot hit and suppress repaired cache saves.

Manual benchmark dispatches can set `publish_results=false`. Measurement and evidence artifacts still run normally, while the privileged report job is skipped so benchmark runs cannot update RTT data or README state.

Dispatches can also set `prepare_only=true` to execute the existing checkout, install, compatibility patch, verification, full-build, and native cache-save path without linking a channel package or starting live RTT work. Prepare-only matrix jobs use a run-scoped concurrency group so they do not queue behind normal channel measurements, while `max-parallel: 1` still lets the first matrix entry seed later exact-source entries in the same run. Normal runs retain the exact `channel-rtt-measure-<channel>` grouping and the `qa-live-shared` environment.

## User Impact

Scheduled and normal manual Release Channel RTT runs retain their existing publication, credential, retry, channel, artifact, and full-build behavior. Exact-source matrix jobs can reuse validated build work instead of repeatedly paying the cold build cost.

Permissions remain split: measurement has `actions: read` and `contents: read`; only the report job has `contents: write`, and that job is skipped for non-publishing benchmarks. The cache excludes `node_modules`, QA evidence, workspace artifacts, RTT imports, and repository data.

Prepare-only mode skips channel linking, sampling, import preparation/upload, diagnostic upload, and the report job even though `publish_results` defaults to true. Both secret expressions remain confined to the skipped sample step, so prepare-only jobs do not materialize live credential environment variables.

## Evidence

- Cold build baseline: 4m59s release + 4m34s QA harness = 9m33s.
- Compressed native cache evidence: 4.77 MB release cache and 4.80 MB QA harness cache.
- Exact-head v2 prepare-only benchmark: https://github.com/openclaw/openclaw-rtt/actions/runs/33867310272 at `95543e2818852edc8f8bd6e049f1e993026f77ff`.
  - cold Slack leg: 317s release + 329s QA = 646s
  - warm cross-channel WhatsApp leg: 233s release + 213s QA = 446s
  - one observed serial hosted reduction: 200s saved, 31.0% reduction, 1.45x faster
- The warm leg restored both outer v2 caches and skipped both save steps. OpenClaw's native cache explicitly restored `tsdown-ai`, `tsdown-packages`, and startup metadata (`write-cli-startup-metadata`). The `tsdown-unified` and plugin-SDK declaration partitions rejected signature mismatches and rebuilt safely.
- Prepare-only behavior was observed end to end: channel linking, sampling, import preparation/upload, diagnostic upload, and the report job were all skipped.
- Benchmark verdict: this single serial hosted run observed a 31.0% reduction and clears the 15% performance gate. It is not a fully deterministic or fully cache-attributable result; long-run savings remain to be measured. The PR remains draft pending the final verdict.
- Run `33861186234` completed and remains the historical cold evidence. Current-task obsolete runs `33864851729`, `33865306984`, and `33866434154` were cancelled because they cannot provide exact-head evidence.
- Focused workflow tests: 24/24 pass.
- Full Node test suite: 200/200 pass.
- Actionlint: pass.
- Repository validators: 431 RTT rows, 645 Discord RTT rows, 2405 channel RTT rows, and 632 surface RTT rows.
- README generation is byte-stable.
- Workflow raw delta: `+99/-27`; discounting the pure 24-line link-step move, functional production/tooling delta is `+75/-3`. Tests: `+181/-4`.

## Follow-Up

Named follow-up: investigate OpenClaw declaration signature instability in the `tsdown-unified` and plugin-SDK partitions, then bump the RTT cache namespace when fixed so repaired native cache records repopulate cleanly.

If build time remains a material share after cache reuse, split release and QA builds into independent artifact-producing jobs, then let credential-bound channel measurement consume those immutable build artifacts. That larger workflow change should be evaluated separately because it changes job topology, artifact transfer, and failure ownership.
