### PR TITLE
fix(qa): isolate candidate release auth serialization and commit patches atomically

### DIFF
--- a/scripts/patch-openclaw-release-qa-harness.mjs
+++ b/scripts/patch-openclaw-release-qa-harness.mjs
@@ -1,8 +1,53 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 const PATCH_ASSET_ROOT = path.dirname(fileURLToPath(import.meta.url));
+
+// Runs inside a one-shot child process whose OPENCLAW_STATE_DIR is the QA
+// state root of exactly one seeding agent. Candidate release auth runtimes
+// read state paths from the process environment (module-evaluation time or
+// per call), so serialization must not share a process-global env window
+// with concurrently seeding agents.
+export const isolatedAuthStoreWorker = `
+import { pathToFileURL } from "node:url";
+
+const chunks = [];
+for await (const chunk of process.stdin) {
+  chunks.push(chunk);
+}
+const input = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+
+const releaseAuthRuntime = await import(
+  pathToFileURL(input.releaseAuthRuntimePath).href
+);
+const loadStore = releaseAuthRuntime.loadAuthProfileStoreWithoutExternalProfiles;
+const saveStore = releaseAuthRuntime.saveAuthProfileStore;
+if (typeof loadStore !== "function" || typeof saveStore !== "function") {
+  throw new Error(
+    "Candidate release auth runtime must export loadAuthProfileStoreWithoutExternalProfiles and saveAuthProfileStore."
+  );
+}
+
+const existing = loadStore(input.agentDir, { inheritedAuthDir: input.agentDir });
+const nextStore = {
+  ...existing,
+  version: 1,
+  profiles: input.replace
+    ? { ...input.profiles }
+    : { ...(existing.profiles ?? {}), ...input.profiles },
+};
+if (input.replace) {
+  delete nextStore.order;
+  delete nextStore.lastGood;
+  delete nextStore.usageStats;
+}
+saveStore(nextStore, input.agentDir, {
+  filterExternalAuthProfiles: false,
+  syncExternalCli: false,
+});
+process.stdout.write(JSON.stringify({ ok: true }));
+`;
 
 const gatewayConfigWriteAnchor = `        await fs.writeFile(configPath, \`\${JSON.stringify(cfg, null, 2)}\\n\`, {
           encoding: "utf8",
@@ -90,45 +135,38 @@ const candidateOwnedAuthStoreWrite = `export async function writeQaAuthProfiles(
     }
     return;
   }
-  const previousStateDir = process.env.OPENCLAW_STATE_DIR;
-  process.env.OPENCLAW_STATE_DIR = params.stateDir;
-  try {
-    // Candidate modules cache state paths during evaluation, so the isolated QA
-    // state root must be active before importing the candidate serializer.
-    const releaseAuthRuntime = await releaseCompat.resolveReleaseAuthRuntime(packageSpec, runtimePath);
-    const loadStore =
-      releaseAuthRuntime?.loadAuthProfileStoreWithoutExternalProfiles ??
-      loadAuthProfileStoreWithoutExternalProfiles;
-    const saveStore = releaseAuthRuntime?.saveAuthProfileStore;
-    if (!saveStore) {
-      throw new Error("Candidate release auth runtime does not export saveAuthProfileStore.");
-    }
-    const existing = loadStore(agentDir, {
-      inheritedAuthDir: agentDir,
+  // Candidate release auth runtimes read their state root from the process
+  // environment, so serialization runs in a one-shot child process whose env
+  // is exactly this seeding agent's state dir. This process never mutates its
+  // own env, so concurrently seeding agents can never observe or clobber each
+  // other's state dir across an await boundary.
+  const { spawn } = await import("node:child_process");
+  const worker = ${JSON.stringify(isolatedAuthStoreWorker)};
+  await new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, ["--input-type=module", "--eval", worker], {
+      env: { ...process.env, OPENCLAW_STATE_DIR: params.stateDir },
+      stdio: ["pipe", "pipe", "pipe"],
     });
-    const nextStore = {
-      ...existing,
-      version: 1,
-      profiles: params.replace
-        ? { ...params.profiles }
-        : { ...existing.profiles, ...params.profiles },
-    };
-    if (params.replace) {
-      delete nextStore.order;
-      delete nextStore.lastGood;
-      delete nextStore.usageStats;
-    }
-    saveStore(nextStore, agentDir, {
-      filterExternalAuthProfiles: false,
-      syncExternalCli: false,
+    let stderr = "";
+    child.stderr.setEncoding("utf8");
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
     });
-  } finally {
-    if (previousStateDir === undefined) {
-      delete process.env.OPENCLAW_STATE_DIR;
-    } else {
-      process.env.OPENCLAW_STATE_DIR = previousStateDir;
-    }
-  }
+    child.on("error", reject);
+    child.on("exit", (code, signal) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(\`Isolated release auth store save failed (\${signal ?? \`exit \${code}\`}): \${stderr.trim()}\`));
+      }
+    });
+    child.stdin.end(JSON.stringify({
+      agentDir,
+      profiles: params.profiles,
+      replace: Boolean(params.replace),
+      releaseAuthRuntimePath,
+    }));
+  });
 }`;
 const unsupportedReplacePathsAnchor = `function isStaleConfigPatchError(error: unknown) {
   return formatErrorMessage(error).toLowerCase().includes("config changed since last load");
@@ -213,9 +251,65 @@ async function preparePatchAsset(sourcePath, targetPath) {
   }
   return {
     contents: source,
+    original: existing,
     path: targetPath,
     staged: existing === undefined,
   };
+}
+
+// Committing the patch as a multi-file set is atomic-enough by construction:
+// every write is staged to a sibling temp file first and only then renamed
+// into place one at a time. If any step fails, files that were already
+// renamed are restored from their recorded original contents (best effort),
+// temp files are cleaned up, and the error names any path that still needs
+// manual recovery.
+export async function commitPatchWrites(writes) {
+  const staged = [];
+  try {
+    for (const { contents, original, path: targetPath } of writes) {
+      const tempPath = path.join(
+        path.dirname(targetPath),
+        `.tmp-${path.basename(targetPath)}`,
+      );
+      await fs.writeFile(tempPath, contents, "utf8");
+      staged.push({ committed: false, original, targetPath, tempPath });
+    }
+    for (const entry of staged) {
+      await fs.rename(entry.tempPath, entry.targetPath);
+      entry.committed = true;
+    }
+  } catch (error) {
+    const needsManualRestore = [];
+    for (const entry of staged) {
+      if (entry.committed) {
+        try {
+          if (entry.original === undefined) {
+            await fs.unlink(entry.targetPath);
+          } else {
+            await fs.writeFile(entry.targetPath, entry.original, "utf8");
+          }
+        } catch {
+          needsManualRestore.push(entry.targetPath);
+        }
+      } else {
+        try {
+          await fs.unlink(entry.tempPath);
+        } catch {
+          // Best-effort temp cleanup only.
+        }
+      }
+    }
+    const message =
+      `release QA patch commit failed (${error instanceof Error ? error.message : String(error)}); ` +
+      `previously moved files were rolled back.`;
+    if (needsManualRestore.length) {
+      throw new Error(
+        `${message} Manual restore needed for: ${needsManualRestore.join(", ")} ` +
+          `(restore the original content or run git checkout -- <path> in the openclaw-qa checkout).`,
+      );
+    }
+    throw new Error(message);
+  }
 }
 
 async function main() {
@@ -288,23 +382,48 @@ async function main() {
     ),
   ]);
 
+  // Each write records the original target contents (undefined for newly
+  // created assets) so commitPatchWrites can roll back already-moved files if
+  // a later rename in the set fails.
   const writes = [];
   if (gatewayPatch.patched) {
-    writes.push(fs.writeFile(gatewaySetupPath, gatewayPatch.contents));
+    writes.push({
+      contents: gatewayPatch.contents,
+      original: originalGatewaySetup,
+      path: gatewaySetupPath,
+    });
   }
   if (authStorePatch.patched) {
-    writes.push(fs.writeFile(authStorePath, authStorePatch.contents));
+    writes.push({
+      contents: authStorePatch.contents,
+      original: originalAuthStore,
+      path: authStorePath,
+    });
   }
   if (replacePathsErrorPatch.patched || liveConfigPatch.patched) {
-    writes.push(fs.writeFile(liveGatewayConfigPath, liveConfigPatch.contents));
+    writes.push({
+      contents: liveConfigPatch.contents,
+      original: originalLiveGatewayConfig,
+      path: liveGatewayConfigPath,
+    });
   }
   if (compatModuleAsset.staged) {
-    writes.push(fs.writeFile(compatModuleAsset.path, compatModuleAsset.contents));
+    writes.push({
+      contents: compatModuleAsset.contents,
+      original: compatModuleAsset.original,
+      path: compatModuleAsset.path,
+    });
   }
   if (compatDeclarationAsset.staged) {
-    writes.push(fs.writeFile(compatDeclarationAsset.path, compatDeclarationAsset.contents));
+    writes.push({
+      contents: compatDeclarationAsset.contents,
+      original: compatDeclarationAsset.original,
+      path: compatDeclarationAsset.path,
+    });
   }
-  await Promise.all(writes);
+  if (writes.length > 0) {
+    await commitPatchWrites(writes);
+  }
 
   const patchCount =
     Number(gatewayPatch.patched) +
@@ -318,7 +437,11 @@ async function main() {
   );
 }
 
-main().catch((error) => {
-  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
-  process.exitCode = 1;
-});
+const isDirectRun =
+  process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (isDirectRun) {
+  main().catch((error) => {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/patch-openclaw-release-qa-harness.test.mjs
+++ b/scripts/patch-openclaw-release-qa-harness.test.mjs
@@ -1,11 +1,16 @@
 import assert from "node:assert/strict";
-import { execFile } from "node:child_process";
+import { execFile, spawn } from "node:child_process";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 import test from "node:test";
+
+import {
+  commitPatchWrites,
+  isolatedAuthStoreWorker,
+} from "./patch-openclaw-release-qa-harness.mjs";
 
 const execFileAsync = promisify(execFile);
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
@@ -111,6 +116,10 @@ async function makeFixture({
   return { authPath, gatewayPath, liveGatewayPath, root };
 }
 
+async function listTempFiles(dir) {
+  return (await fs.readdir(dir)).filter((name) => name.startsWith(".tmp-"));
+}
+
 test("patches release config and auth serialization contracts idempotently", async (t) => {
   const { authPath, gatewayPath, liveGatewayPath, root } = await makeFixture();
   t.after(() => fs.rm(root, { force: true, recursive: true }));
@@ -125,12 +134,12 @@ test("patches release config and auth serialization contracts idempotently", asy
 
   const patchedAuth = await fs.readFile(authPath, "utf8");
   assert.match(patchedAuth, /OPENCLAW_QA_RELEASE_AUTH_RUNTIME_PATH/u);
-  assert.match(patchedAuth, /releaseAuthRuntime\?\.saveAuthProfileStore/u);
-  assert.match(patchedAuth, /process\.env\.OPENCLAW_STATE_DIR = params\.stateDir/u);
-  assert.ok(
-    patchedAuth.indexOf("process.env.OPENCLAW_STATE_DIR = params.stateDir") <
-      patchedAuth.indexOf("await releaseCompat.resolveReleaseAuthRuntime"),
-  );
+  assert.match(patchedAuth, /resolveReleaseAuthRuntimePath/u);
+  // Candidate serialization must not mutate the parent process env: state dir
+  // reaches the candidate runtime only through the spawned child's env.
+  assert.doesNotMatch(patchedAuth, /process\.env\.OPENCLAW_STATE_DIR\s*=/u);
+  assert.match(patchedAuth, /OPENCLAW_STATE_DIR: params\.stateDir/u);
+  assert.match(patchedAuth, /spawn\(process\.execPath, \["--input-type=module", "--eval", worker\]/u);
   assert.match(patchedAuth, /updateAuthProfileStoreWithLock/u);
 
   const patchedLiveGateway = await fs.readFile(liveGatewayPath, "utf8");
@@ -159,6 +168,7 @@ test("patches release config and auth serialization contracts idempotently", asy
     await fs.readFile(compatDeclarationPath, "utf8"),
     await fs.readFile(path.join(REPO_ROOT, "scripts/release-qa-config-compat.d.mts"), "utf8"),
   );
+  assert.deepEqual(await listTempFiles(root), []);
 
   const second = await execFileAsync(process.execPath, [PATCH_SCRIPT, root]);
   assert.match(second.stdout, /already patched/u);
@@ -175,4 +185,232 @@ test("fails closed when the upstream release QA contract changes", async (t) => 
     execFileAsync(process.execPath, [PATCH_SCRIPT, root]),
     /Unsupported release QA gateway config contract/u,
   );
+});
+
+// A fake candidate release auth runtime that binds its state root from the
+// process env at call time, like the historical releases the patch targets.
+// It records the observed env root and widens its write window so concurrent
+// agents overlap, which would expose any cross-agent env sharing.
+async function makeFakeReleaseAuthRuntime(dir) {
+  const runtimePath = path.join(dir, "fake-release-auth-runtime.mjs");
+  await fs.writeFile(
+    runtimePath,
+    `import fs from "node:fs";
+import path from "node:path";
+
+function readStateRoot() {
+  const stateRoot = process.env.OPENCLAW_STATE_DIR;
+  if (!stateRoot || stateRoot.trim() === "") {
+    throw new Error("candidate release auth runtime requires OPENCLAW_STATE_DIR");
+  }
+  return stateRoot;
+}
+
+function storePath() {
+  return path.join(readStateRoot(), "auth-profiles.json");
+}
+
+export function loadAuthProfileStoreWithoutExternalProfiles(agentDir, options) {
+  if (options?.inheritedAuthDir !== agentDir) {
+    throw new Error("unexpected inheritedAuthDir in load");
+  }
+  try {
+    return JSON.parse(fs.readFileSync(storePath(), "utf8"));
+  } catch {
+    return { version: 0, profiles: {}, meta: { observedRoot: readStateRoot() } };
+  }
+}
+
+export function saveAuthProfileStore(store, agentDir, options) {
+  if (options?.filterExternalAuthProfiles !== false || options?.syncExternalCli !== false) {
+    throw new Error("unexpected save options");
+  }
+  const deadline = Date.now() + 50;
+  while (Date.now() < deadline) {
+    // Busy-wait so concurrent seeding agents overlap inside the runtime.
+  }
+  store.meta = { ...store.meta, observedRoot: readStateRoot() };
+  fs.writeFileSync(storePath(), JSON.stringify(store, null, 2));
+}
+`,
+    "utf8",
+  );
+  return runtimePath;
+}
+
+function runIsolatedAuthStoreWorker({ agentDir, profiles, releaseAuthRuntimePath, replace, stateDir }) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(
+      process.execPath,
+      ["--input-type=module", "--eval", isolatedAuthStoreWorker],
+      {
+        env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
+        stdio: ["pipe", "pipe", "pipe"],
+      },
+    );
+    let stderr = "";
+    child.stderr.setEncoding("utf8");
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+    });
+    child.on("error", reject);
+    child.on("exit", (code, signal) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(
+          new Error(
+            `Isolated release auth store save failed (${signal ?? `exit ${code}`}): ${stderr.trim()}`,
+          ),
+        );
+      }
+    });
+    child.stdin.end(
+      JSON.stringify({ agentDir, profiles, releaseAuthRuntimePath, replace: Boolean(replace) }),
+    );
+  });
+}
+
+test("concurrent seeding agents keep their auth stores in disjoint state roots", async (t) => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-release-qa-seed-isolation-"));
+  t.after(() => fs.rm(root, { force: true, recursive: true }));
+
+  const runtimePath = await makeFakeReleaseAuthRuntime(root);
+  const stateA = path.join(root, "state-a");
+  const stateB = path.join(root, "state-b");
+  const agentA = path.join(stateA, "agents/agent-a");
+  const agentB = path.join(stateB, "agents/agent-b");
+  await Promise.all([
+    fs.mkdir(agentA, { recursive: true }),
+    fs.mkdir(agentB, { recursive: true }),
+  ]);
+
+  await Promise.all([
+    runIsolatedAuthStoreWorker({
+      agentDir: agentA,
+      profiles: { "pA@example.com": { type: "bearer", token: "token-a" } },
+      releaseAuthRuntimePath: runtimePath,
+      stateDir: stateA,
+    }),
+    runIsolatedAuthStoreWorker({
+      agentDir: agentB,
+      profiles: { "pB@example.com": { type: "bearer", token: "token-b" } },
+      releaseAuthRuntimePath: runtimePath,
+      stateDir: stateB,
+    }),
+  ]);
+
+  assert.equal(process.env.OPENCLAW_STATE_DIR, undefined);
+  const storeA = JSON.parse(await fs.readFile(path.join(stateA, "auth-profiles.json"), "utf8"));
+  const storeB = JSON.parse(await fs.readFile(path.join(stateB, "auth-profiles.json"), "utf8"));
+  assert.equal(storeA.meta.observedRoot, stateA);
+  assert.equal(storeB.meta.observedRoot, stateB);
+  assert.deepEqual(Object.keys(storeA.profiles), ["pA@example.com"]);
+  assert.deepEqual(Object.keys(storeB.profiles), ["pB@example.com"]);
+  assert.equal(storeA.version, 1);
+  assert.equal(storeB.version, 1);
+
+  // A replace=true write must wipe bookkeeping fields and leave the other
+  // agent's store untouched.
+  await runIsolatedAuthStoreWorker({
+    agentDir: agentA,
+    profiles: { "pA2@example.com": { type: "bearer", token: "token-a2" } },
+    releaseAuthRuntimePath: runtimePath,
+    replace: true,
+    stateDir: stateA,
+  });
+  const replacedA = JSON.parse(await fs.readFile(path.join(stateA, "auth-profiles.json"), "utf8"));
+  assert.deepEqual(Object.keys(replacedA.profiles), ["pA2@example.com"]);
+  assert.equal(replacedA.order, undefined);
+  assert.equal(replacedA.lastGood, undefined);
+  assert.equal(replacedA.usageStats, undefined);
+  const untouchedB = JSON.parse(await fs.readFile(path.join(stateB, "auth-profiles.json"), "utf8"));
+  assert.deepEqual(Object.keys(untouchedB.profiles), ["pB@example.com"]);
+});
+
+test("isolated worker fails closed when the candidate runtime lacks the store contract", async (t) => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-release-qa-seed-failclosed-"));
+  t.after(() => fs.rm(root, { force: true, recursive: true }));
+
+  const runtimePath = path.join(root, "incomplete-release-auth-runtime.mjs");
+  await fs.writeFile(
+    runtimePath,
+    'export function loadAuthProfileStoreWithoutExternalProfiles() { return { profiles: {} }; }\n',
+    "utf8",
+  );
+  const stateDir = path.join(root, "state");
+  await fs.mkdir(path.join(stateDir, "agents/agent-a"), { recursive: true });
+
+  await assert.rejects(
+    runIsolatedAuthStoreWorker({
+      agentDir: path.join(stateDir, "agents/agent-a"),
+      profiles: { "p@example.com": { type: "bearer", token: "token" } },
+      releaseAuthRuntimePath: runtimePath,
+      stateDir,
+    }),
+    /must export loadAuthProfileStoreWithoutExternalProfiles and saveAuthProfileStore/u,
+  );
+});
+
+test("commitPatchWrites restores already-renamed files when a later rename fails", async (t) => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-release-qa-rollback-"));
+  t.after(() => fs.rm(root, { force: true, recursive: true }));
+
+  const firstPath = path.join(root, "first.txt");
+  const blockedDirPath = path.join(root, "blocked.txt");
+  const lastPath = path.join(root, "last.txt");
+  await fs.writeFile(firstPath, "first-original\n", "utf8");
+  await fs.mkdir(blockedDirPath);
+  await fs.writeFile(lastPath, "last-original\n", "utf8");
+
+  await assert.rejects(
+    commitPatchWrites([
+      { contents: "first-patched\n", original: "first-original\n", path: firstPath },
+      // Renaming a file onto an existing directory fails, after first.txt was
+      // already committed.
+      { contents: "blocked\n", path: blockedDirPath },
+      { contents: "last-patched\n", original: "last-original\n", path: lastPath },
+    ]),
+    /release QA patch commit failed.*previously moved files were rolled back/u,
+  );
+
+  assert.equal(await fs.readFile(firstPath, "utf8"), "first-original\n");
+  assert.equal(await fs.readFile(lastPath, "utf8"), "last-original\n");
+  assert.deepEqual((await fs.stat(blockedDirPath)).isDirectory(), true);
+  assert.deepEqual(await listTempFiles(root), []);
+});
+
+test("commitPatchWrites leaves targets untouched when a temp write fails mid-staging", async (t) => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-release-qa-stagefail-"));
+  t.after(async () => {
+    await fs.chmod(path.join(root, "read-only"), 0o755);
+    await fs.rm(root, { force: true, recursive: true });
+  });
+
+  const writableDir = path.join(root, "writable");
+  const readOnlyDir = path.join(root, "read-only");
+  await fs.mkdir(writableDir);
+  await fs.mkdir(readOnlyDir);
+  await fs.chmod(readOnlyDir, 0o555);
+  const firstPath = path.join(writableDir, "first.txt");
+  const blockedPath = path.join(readOnlyDir, "blocked.txt");
+  const lastPath = path.join(writableDir, "last.txt");
+  await Promise.all([
+    fs.writeFile(firstPath, "first-original\n", "utf8"),
+    fs.writeFile(lastPath, "last-original\n", "utf8"),
+  ]);
+
+  await assert.rejects(
+    commitPatchWrites([
+      { contents: "first-patched\n", original: "first-original\n", path: firstPath },
+      { contents: "blocked-patched\n", original: "blocked-original\n", path: blockedPath },
+      { contents: "last-patched\n", original: "last-original\n", path: lastPath },
+    ]),
+    /release QA patch commit failed/u,
+  );
+
+  assert.equal(await fs.readFile(firstPath, "utf8"), "first-original\n");
+  assert.equal(await fs.readFile(lastPath, "utf8"), "last-original\n");
+  assert.equal(await fs.access(blockedPath).then(() => true, () => false), false);
+  assert.deepEqual(await listTempFiles(writableDir), []);
 });


### PR DESCRIPTION
Fixes openclaw/openclaw#119679

## Summary

Seeding agents that target candidate release auth runtimes previously swapped `OPENCLAW_STATE_DIR` on the shared process env across an await boundary, letting concurrent `Promise.all` seeding observe or clobber each other's state root. The candidate serializer now runs in a one-shot child process whose env carries exactly the seeding agent's state dir; the parent never mutates its own env.

Multi-file patch writes now stage sibling `.tmp-` files and move them into place with `fs.rename`, restoring already-moved files (best effort) when a later rename fails and reporting paths that still need manual recovery.

Scope is limited to `scripts/patch-openclaw-release-qa-harness.mjs` and its test file.

## Note on the issue reference

The issue references a Telegram patcher file that is no longer present in this repository (retired; no add/delete history, and `scripts/telegram-rtt-workflow-contract.test.mjs` asserts the retired helper paths are absent). This change addresses the still-relevant part of the contract: isolated candidate-release auth serialization plus atomic patch commit/rollback.

## Testing

- `node --test scripts/*.test.mjs`: 204 tests / 201 pass / 0 fail / 3 cancelled (pre-existing wait-for-ready cancellations, unchanged from baseline).
- Patcher suite: `node --test scripts/patch-openclaw-release-qa-harness.test.mjs` → 6/6 pass.
- `npm run check` passes.
- Independent harness coverage: two-agent concurrent seeding with separate state dirs (no env leakage, no profile cross-talk); fail-closed runtime contract (missing export name surfaced in the worker error); fault-injected rename failure (already-moved files restored, untouched files intact, no `.tmp-*` residue, rollback guidance in the error); idempotency (second run reports already patched, artifacts byte-identical).
